### PR TITLE
[infra] spring boot 버전 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.0'
+	id 'org.springframework.boot' version '3.3.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'com.diffplug.spotless' version '6.25.0'
 }


### PR DESCRIPTION
### 💻 작업 내용
- 기존 spring boot 3.5.0 은 swagger에 호환되지 않아 에러 발생 
- spring boot 3.5.0 에서 swagger와 호환되는 spring boot 3.3.1 로 변경

### ✨ 리뷰 포인트


### 📝 메모

### 🎯 관련 이슈
closed #40 
