### PR TITLE
[Infra] Swagger 경로 Spring Security 예외 처리

### DIFF
--- a/src/main/java/com/simpleboard/board/global/config/SecurityConfig.java
+++ b/src/main/java/com/simpleboard/board/global/config/SecurityConfig.java
@@ -1,0 +1,27 @@
+package com.simpleboard.board.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http.csrf(csrf -> csrf.disable())
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**")
+                    .permitAll()
+                    .anyRequest()
+                    .permitAll())
+        .formLogin(form -> form.disable())
+        .httpBasic(basic -> basic.disable());
+
+    return http.build();
+  }
+}


### PR DESCRIPTION
### 💻 작업 내용
- SecurityFilterChain 설정에서 Swagger 관련 경로(`/v3/api-docs/**`, `/swagger-ui.html`, `/swagger-ui/**`)에 대해 인증 없이 접근 가능하도록 설정
- CSRF, FormLogin, HttpBasic 비활성화로 API 테스트 환경 개선

### 📝 메모
- Swagger를  사용하기 위해 Spring Security 예외 처리를 진행했습니다.

### 🎯 관련 이슈
closed #51 
