### PR TITLE
[Permission] permission presentation 계층 구현

### DIFF
--- a/src/main/java/com/simpleboard/board/permission/presentation/PermissionController.java
+++ b/src/main/java/com/simpleboard/board/permission/presentation/PermissionController.java
@@ -1,9 +1,11 @@
 package com.simpleboard.board.permission.presentation;
 
 import com.simpleboard.board.permission.application.command.PermissionCommandService;
-import com.simpleboard.board.permission.application.command.dto.DelegateRoleCommand;
 import com.simpleboard.board.permission.presentation.converter.DelegateRoleConverter;
 import com.simpleboard.board.permission.presentation.dto.DelegateRoleForm;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,16 +32,27 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * @domain adapter-in
  */
+@Tag(name = "Permission API", description = "게시판 권한 관리 API")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/permissions")
 public class PermissionController {
+
   private final PermissionCommandService permissionCommandService;
 
+  @Operation(
+      summary = "게시판 권한 위임",
+      description = "특정 게시판의 권한을 다른 사용자에게 위임합니다."
+  )
   @PostMapping("/boards/{boardId}/delegate")
   public ResponseEntity<Void> delegateRole(
-      @PathVariable Long boardId, @RequestBody DelegateRoleForm form) {
-
+      @Parameter(description = "게시판 ID", required = true) @PathVariable Long boardId,
+      @io.swagger.v3.oas.annotations.parameters.RequestBody(
+          description = "권한 위임 정보",
+          required = true
+      )
+      @RequestBody DelegateRoleForm form
+  ) {
     permissionCommandService.delegateRole(
         boardId,
         DelegateRoleConverter.toCommand(form)

--- a/src/main/java/com/simpleboard/board/permission/presentation/PermissionController.java
+++ b/src/main/java/com/simpleboard/board/permission/presentation/PermissionController.java
@@ -2,6 +2,7 @@ package com.simpleboard.board.permission.presentation;
 
 import com.simpleboard.board.permission.application.command.PermissionCommandService;
 import com.simpleboard.board.permission.application.command.dto.DelegateRoleCommand;
+import com.simpleboard.board.permission.presentation.converter.DelegateRoleConverter;
 import com.simpleboard.board.permission.presentation.dto.DelegateRoleForm;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,9 +21,11 @@ public class PermissionController {
   @PostMapping("/boards/{boardId}/delegate")
   public ResponseEntity<Void> delegateRole(
       @PathVariable Long boardId, @RequestBody DelegateRoleForm form) {
+
     permissionCommandService.delegateRole(
         boardId,
-        new DelegateRoleCommand(form.fromUserId(), form.toUserNickname(), form.roleType()));
+        DelegateRoleConverter.toCommand(form)
+    );
     return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/simpleboard/board/permission/presentation/PermissionController.java
+++ b/src/main/java/com/simpleboard/board/permission/presentation/PermissionController.java
@@ -1,0 +1,28 @@
+package com.simpleboard.board.permission.presentation;
+
+import com.simpleboard.board.permission.application.command.PermissionCommandService;
+import com.simpleboard.board.permission.application.command.dto.DelegateRoleCommand;
+import com.simpleboard.board.permission.presentation.dto.DelegateRoleForm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/permissions")
+public class PermissionController {
+  private final PermissionCommandService permissionCommandService;
+
+  @PostMapping("/boards/{boardId}/delegate")
+  public ResponseEntity<Void> delegateRole(
+      @PathVariable Long boardId, @RequestBody DelegateRoleForm form) {
+    permissionCommandService.delegateRole(
+        boardId,
+        new DelegateRoleCommand(form.fromUserId(), form.toUserNickname(), form.roleType()));
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/simpleboard/board/permission/presentation/PermissionController.java
+++ b/src/main/java/com/simpleboard/board/permission/presentation/PermissionController.java
@@ -12,6 +12,24 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * <h2>PermissionController</h2>
+ *
+ * <p>게시판 권한 위임 관련 API를 제공합니다.</p>
+ *
+ * <table>
+ *   <caption>API 목록</caption>
+ *   <tr>
+ *     <td>POST</td>
+ *     <td>/permissions/boards/{boardId}/delegate</td>
+ *     <td>특정 게시판에서 권한을 다른 사용자에게 위임</td>
+ *   </tr>
+ * </table>
+ *
+ * <p><b>권한</b> : 권한 위임</p>
+ *
+ * @domain adapter-in
+ */
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/permissions")

--- a/src/main/java/com/simpleboard/board/permission/presentation/PermissionEventHandler.java
+++ b/src/main/java/com/simpleboard/board/permission/presentation/PermissionEventHandler.java
@@ -1,0 +1,28 @@
+package com.simpleboard.board.permission.presentation;
+
+import com.simpleboard.board.permission.application.command.PermissionCommandService;
+import com.simpleboard.board.permission.presentation.tmp.BoardCreatedEvent;
+import com.simpleboard.board.permission.presentation.tmp.BoardDeletedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PermissionEventHandler {
+
+  private final PermissionCommandService permissionCommandService;
+
+  @Async
+  @EventListener
+  public void handleBoardCreated(BoardCreatedEvent event) {
+    permissionCommandService.createPermissionPolicy(event.boardId(), event.userId());
+  }
+
+  @Async
+  @EventListener
+  public void handleBoardDeleted(BoardDeletedEvent event) {
+    permissionCommandService.deletePermissionPolicy(event.boardId());
+  }
+}

--- a/src/main/java/com/simpleboard/board/permission/presentation/PermissionEventHandler.java
+++ b/src/main/java/com/simpleboard/board/permission/presentation/PermissionEventHandler.java
@@ -1,28 +1,11 @@
 package com.simpleboard.board.permission.presentation;
 
-import com.simpleboard.board.permission.application.command.PermissionCommandService;
 import com.simpleboard.board.permission.presentation.tmp.BoardCreatedEvent;
 import com.simpleboard.board.permission.presentation.tmp.BoardDeletedEvent;
-import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Component;
 
-@Component
-@RequiredArgsConstructor
-public class PermissionEventHandler {
+public interface PermissionEventHandler {
 
-  private final PermissionCommandService permissionCommandService;
+  void handleBoardCreated(BoardCreatedEvent event);
 
-  @Async
-  @EventListener
-  public void handleBoardCreated(BoardCreatedEvent event) {
-    permissionCommandService.createPermissionPolicy(event.boardId(), event.userId());
-  }
-
-  @Async
-  @EventListener
-  public void handleBoardDeleted(BoardDeletedEvent event) {
-    permissionCommandService.deletePermissionPolicy(event.boardId());
-  }
+  void handleBoardDeleted(BoardDeletedEvent event);
 }

--- a/src/main/java/com/simpleboard/board/permission/presentation/PermissionEventHandlerImpl.java
+++ b/src/main/java/com/simpleboard/board/permission/presentation/PermissionEventHandlerImpl.java
@@ -1,0 +1,28 @@
+package com.simpleboard.board.permission.presentation;
+
+import com.simpleboard.board.permission.application.command.PermissionCommandService;
+import com.simpleboard.board.permission.presentation.tmp.BoardCreatedEvent;
+import com.simpleboard.board.permission.presentation.tmp.BoardDeletedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PermissionEventHandlerImpl implements PermissionEventHandler{
+
+  private final PermissionCommandService permissionCommandService;
+
+  @Async
+  @EventListener
+  public void handleBoardCreated(BoardCreatedEvent event) {
+    permissionCommandService.createPermissionPolicy(event.boardId(), event.userId());
+  }
+
+  @Async
+  @EventListener
+  public void handleBoardDeleted(BoardDeletedEvent event) {
+    permissionCommandService.deletePermissionPolicy(event.boardId());
+  }
+}

--- a/src/main/java/com/simpleboard/board/permission/presentation/PermissionFakeController.java
+++ b/src/main/java/com/simpleboard/board/permission/presentation/PermissionFakeController.java
@@ -9,6 +9,29 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * <h2>PermissionFakeController (테스트용 권한 컨트롤러)</h2>
+ *
+ * <p>테스트 목적의 임시 API를 제공합니다.</p>
+ *
+ * <table>
+ *   <caption>API 목록</caption>
+ *   <tr>
+ *     <td>GET</td>
+ *     <td>/test/permissions/boards/{boardId}/create?userId=</td>
+ *     <td>지정한 boardId와 userId로 권한 정책 생성</td>
+ *   </tr>
+ *   <tr>
+ *     <td>GET</td>
+ *     <td>/test/permissions/boards/{boardId}/delete?userId=</td>
+ *     <td>지정한 boardId에 대한 권한 정책 삭제</td>
+ *   </tr>
+ * </table>
+ *
+ * <p><b>권한</b> : 테스트 권한 생성/삭제</p>
+ *
+ * @domain adapter-in
+ */
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/test/permissions")

--- a/src/main/java/com/simpleboard/board/permission/presentation/PermissionFakeController.java
+++ b/src/main/java/com/simpleboard/board/permission/presentation/PermissionFakeController.java
@@ -2,6 +2,7 @@ package com.simpleboard.board.permission.presentation;
 
 import com.simpleboard.board.permission.application.command.PermissionCommandService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -35,6 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/test/permissions")
+@Profile("dev")
 public class PermissionFakeController {
   private final PermissionCommandService permissionCommandService;
 

--- a/src/main/java/com/simpleboard/board/permission/presentation/PermissionFakeController.java
+++ b/src/main/java/com/simpleboard/board/permission/presentation/PermissionFakeController.java
@@ -1,0 +1,31 @@
+package com.simpleboard.board.permission.presentation;
+
+import com.simpleboard.board.permission.application.command.PermissionCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/test/permissions")
+public class PermissionFakeController {
+  private final PermissionCommandService permissionCommandService;
+
+  @GetMapping("/boards/{boardId}/create")
+  public ResponseEntity<Void> createPermissionPolicy(
+      @PathVariable Long boardId, @RequestParam Long userId) {
+    permissionCommandService.createPermissionPolicy(boardId, userId);
+    return ResponseEntity.ok().build();
+  }
+
+  @GetMapping("/boards/{boardId}/delete")
+  public ResponseEntity<Void> deletePermissionPolicy(
+      @PathVariable Long boardId, @RequestParam Long userId) {
+    permissionCommandService.deletePermissionPolicy(boardId);
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/simpleboard/board/permission/presentation/PermissionFakeController.java
+++ b/src/main/java/com/simpleboard/board/permission/presentation/PermissionFakeController.java
@@ -36,7 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/test/permissions")
-@Profile("dev")
+@Profile("!prod")
 public class PermissionFakeController {
   private final PermissionCommandService permissionCommandService;
 

--- a/src/main/java/com/simpleboard/board/permission/presentation/PermissionInternalController.java
+++ b/src/main/java/com/simpleboard/board/permission/presentation/PermissionInternalController.java
@@ -1,6 +1,9 @@
 package com.simpleboard.board.permission.presentation;
 
 import com.simpleboard.board.permission.application.query.PermissionQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * @domain adapter-in
  */
+@Tag(name = "Permission Internal API", description = "게시판 권한 관련 내부 API")
 @RestController
 @RequestMapping("/internal/permissions")
 @RequiredArgsConstructor
@@ -35,9 +39,15 @@ public class PermissionInternalController {
 
   private final PermissionQueryService permissionQueryService;
 
+  @Operation(
+      summary = "게시판 삭제 권한 확인",
+      description = "해당 사용자가 지정한 게시판을 삭제할 권한이 있는지 확인합니다."
+  )
   @GetMapping("/boards/{boardId}/delete")
   public ResponseEntity<CanDeleteResponse> checkBoardDeletePermission(
-      @PathVariable Long boardId, @RequestParam Long userId) {
+      @Parameter(description = "게시판 ID", required = true) @PathVariable Long boardId,
+      @Parameter(description = "사용자 ID", required = true) @RequestParam Long userId
+  ) {
     boolean canDelete = permissionQueryService.checkBoardDeletePermission(boardId, userId);
     return ResponseEntity.ok(new CanDeleteResponse(canDelete));
   }

--- a/src/main/java/com/simpleboard/board/permission/presentation/PermissionInternalController.java
+++ b/src/main/java/com/simpleboard/board/permission/presentation/PermissionInternalController.java
@@ -1,0 +1,27 @@
+package com.simpleboard.board.permission.presentation;
+
+import com.simpleboard.board.permission.application.query.PermissionQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/permissions")
+@RequiredArgsConstructor
+public class PermissionInternalController {
+
+  private final PermissionQueryService permissionQueryService;
+
+  @GetMapping("/boards/{boardId}/delete")
+  public ResponseEntity<CanDeleteResponse> checkBoardDeletePermission(
+      @PathVariable Long boardId, @RequestParam Long userId) {
+    boolean canDelete = permissionQueryService.checkBoardDeletePermission(boardId, userId);
+    return ResponseEntity.ok(new CanDeleteResponse(canDelete));
+  }
+
+  public record CanDeleteResponse(boolean canDelete) {}
+}

--- a/src/main/java/com/simpleboard/board/permission/presentation/PermissionInternalController.java
+++ b/src/main/java/com/simpleboard/board/permission/presentation/PermissionInternalController.java
@@ -9,6 +9,25 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+
+/**
+ * <h2>PermissionInternalController</h2>
+ *
+ * <p>게시판 삭제 권한 확인을 위한 내부 API를 제공합니다.</p>
+ *
+ * <table>
+ *   <caption>API 목록</caption>
+ *   <tr>
+ *     <td>GET</td>
+ *     <td>/internal/permissions/boards/{boardId}/delete?userId=</td>
+ *     <td>해당 사용자가 게시판 삭제 권한을 가졌는지 확인</td>
+ *   </tr>
+ * </table>
+ *
+ * <p><b>권한</b> : 삭제 권한 조회</p>
+ *
+ * @domain adapter-in
+ */
 @RestController
 @RequestMapping("/internal/permissions")
 @RequiredArgsConstructor

--- a/src/main/java/com/simpleboard/board/permission/presentation/converter/DelegateRoleConverter.java
+++ b/src/main/java/com/simpleboard/board/permission/presentation/converter/DelegateRoleConverter.java
@@ -1,0 +1,19 @@
+package com.simpleboard.board.permission.presentation.converter;
+
+import com.simpleboard.board.permission.application.command.dto.DelegateRoleCommand;
+import com.simpleboard.board.permission.presentation.dto.DelegateRoleForm;
+
+public class DelegateRoleConverter {
+
+  private DelegateRoleConverter() {
+    throw new UnsupportedOperationException("Utility class");
+  }
+
+  public static DelegateRoleCommand toCommand(DelegateRoleForm form) {
+    return new DelegateRoleCommand(
+        form.fromUserId(),
+        form.toUserNickname(),
+        form.roleType()
+    );
+  }
+}

--- a/src/main/java/com/simpleboard/board/permission/presentation/dto/DelegateRoleForm.java
+++ b/src/main/java/com/simpleboard/board/permission/presentation/dto/DelegateRoleForm.java
@@ -1,0 +1,5 @@
+package com.simpleboard.board.permission.presentation.dto;
+
+import com.simpleboard.board.permission.domain.RoleName;
+
+public record DelegateRoleForm(Long fromUserId, String toUserNickname, RoleName roleType) {}

--- a/src/main/java/com/simpleboard/board/permission/presentation/tmp/BoardCreatedEvent.java
+++ b/src/main/java/com/simpleboard/board/permission/presentation/tmp/BoardCreatedEvent.java
@@ -1,0 +1,3 @@
+package com.simpleboard.board.permission.presentation.tmp;
+
+public record BoardCreatedEvent(Long boardId, Long userId) {}

--- a/src/main/java/com/simpleboard/board/permission/presentation/tmp/BoardDeletedEvent.java
+++ b/src/main/java/com/simpleboard/board/permission/presentation/tmp/BoardDeletedEvent.java
@@ -1,0 +1,3 @@
+package com.simpleboard.board.permission.presentation.tmp;
+
+public record BoardDeletedEvent(Long boardId) {}

--- a/src/test/java/com/simpleboard/board/permission/presentation/PermissionControllerTest.java
+++ b/src/test/java/com/simpleboard/board/permission/presentation/PermissionControllerTest.java
@@ -1,0 +1,51 @@
+package com.simpleboard.board.permission.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.simpleboard.board.permission.application.command.PermissionCommandService;
+import com.simpleboard.board.permission.presentation.dto.DelegateRoleForm;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.simpleboard.board.permission.domain.RoleName.BOARD_ADMIN;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+@WebMvcTest(PermissionController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PermissionControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private PermissionCommandService permissionCommandService;
+
+  @Test
+  @DisplayName("권한 위임 요청 시 200 응답 반환")
+  void delegateRole() throws Exception {
+    // given
+    Long boardId = 1L;
+    DelegateRoleForm form = new DelegateRoleForm(10L, "receiverUser", BOARD_ADMIN);
+
+    // when & then
+    mockMvc.perform(post("/permissions/boards/{boardId}/delegate", boardId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(form)))
+        .andExpect(status().isOk());
+
+    // verify service was called
+    Mockito.verify(permissionCommandService)
+        .delegateRole(Mockito.eq(boardId), Mockito.any());
+  }
+}

--- a/src/test/java/com/simpleboard/board/permission/presentation/PermissionEventHandlerImplTest.java
+++ b/src/test/java/com/simpleboard/board/permission/presentation/PermissionEventHandlerImplTest.java
@@ -16,8 +16,8 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import static org.mockito.Mockito.*;
 
 @SpringJUnitConfig
-@ContextConfiguration(classes = PermissionEventHandlerTest.TestConfig.class)
-class PermissionEventHandlerTest {
+@ContextConfiguration(classes = PermissionEventHandlerImplTest.TestConfig.class)
+class PermissionEventHandlerImplTest {
 
   @Autowired
   private ApplicationEventPublisher eventPublisher;
@@ -53,7 +53,7 @@ class PermissionEventHandlerTest {
   }
 
   @Configuration
-  @Import(PermissionEventHandler.class)
+  @Import(PermissionEventHandlerImpl.class)
   static class TestConfig {
 
     @Bean

--- a/src/test/java/com/simpleboard/board/permission/presentation/PermissionEventHandlerTest.java
+++ b/src/test/java/com/simpleboard/board/permission/presentation/PermissionEventHandlerTest.java
@@ -1,0 +1,64 @@
+package com.simpleboard.board.permission.presentation;
+
+import com.simpleboard.board.permission.application.command.PermissionCommandService;
+import com.simpleboard.board.permission.presentation.tmp.BoardCreatedEvent;
+import com.simpleboard.board.permission.presentation.tmp.BoardDeletedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.mockito.Mockito.*;
+
+@SpringJUnitConfig
+@ContextConfiguration(classes = PermissionEventHandlerTest.TestConfig.class)
+class PermissionEventHandlerTest {
+
+  @Autowired
+  private ApplicationEventPublisher eventPublisher;
+
+  @Autowired
+  private PermissionCommandService permissionCommandService;
+
+  @Test
+  @DisplayName("BoardCreatedEvent 발생 시 createPermissionPolicy가 호출된다")
+  void handleBoardCreatedEvent() {
+    // given
+    Long boardId = 1L;
+    Long userId = 100L;
+
+    // when
+    eventPublisher.publishEvent(new BoardCreatedEvent(boardId, userId));
+
+    // then
+    verify(permissionCommandService, timeout(500)).createPermissionPolicy(boardId, userId);
+  }
+
+  @Test
+  @DisplayName("BoardDeletedEvent 발생 시 deletePermissionPolicy가 호출된다")
+  void handleBoardDeletedEvent() {
+    // given
+    Long boardId = 2L;
+
+    // when
+    eventPublisher.publishEvent(new BoardDeletedEvent(boardId));
+
+    // then
+    verify(permissionCommandService, timeout(500)).deletePermissionPolicy(boardId);
+  }
+
+  @Configuration
+  @Import(PermissionEventHandler.class)
+  static class TestConfig {
+
+    @Bean
+    public PermissionCommandService permissionCommandService() {
+      return mock(PermissionCommandService.class);
+    }
+  }
+}

--- a/src/test/java/com/simpleboard/board/permission/presentation/PermissionInternalControllerTest.java
+++ b/src/test/java/com/simpleboard/board/permission/presentation/PermissionInternalControllerTest.java
@@ -1,0 +1,57 @@
+package com.simpleboard.board.permission.presentation;
+
+import com.simpleboard.board.permission.application.query.PermissionQueryService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@WebMvcTest(PermissionInternalController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PermissionInternalControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private PermissionQueryService permissionQueryService;
+
+  @Test
+  @DisplayName("삭제 권한이 있는 경우 true 반환")
+  void checkBoardDeletePermission_true() throws Exception {
+    // given
+    Mockito.when(permissionQueryService.checkBoardDeletePermission(anyLong(), anyLong()))
+        .thenReturn(true);
+
+    // when & then
+    mockMvc.perform(MockMvcRequestBuilders
+            .get("/internal/permissions/boards/1/delete")
+            .param("userId", "100"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.canDelete").value(true));
+  }
+
+  @Test
+  @DisplayName("삭제 권한이 없는 경우 false 반환")
+  void checkBoardDeletePermission_false() throws Exception {
+    // given
+    Mockito.when(permissionQueryService.checkBoardDeletePermission(anyLong(), anyLong()))
+        .thenReturn(false);
+
+    // when & then
+    mockMvc.perform(MockMvcRequestBuilders
+            .get("/internal/permissions/boards/1/delete")
+            .param("userId", "100"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.canDelete").value(false));
+  }
+}


### PR DESCRIPTION
### 💻 작업 내용
- permission 도메인의 presentation 계층을 구현했습니다.
- PermissionFakeController 에는 Profile 어노테이션을 통해 dev 환경일 때만 Bean 등록되게 설정했습니다.

### ✨ 리뷰 포인트
- 

### 📝 메모
- 이벤트로 처리될 Service들을 호출해보기 위해 FakeController를 생성했습니다.
- event 처리를 위해 tmp 디렉토리 아래에 Event 객체들을 생성했습니다.

### 🎯 관련 이슈
closed #49 