### PR TITLE
[Auth] Token 탈취 시 특정 회원에 대한 기발급 토큰 블락 기능 추가

### DIFF
--- a/src/main/java/com/simpleboard/board/auth/domain/common/vo/Role.java
+++ b/src/main/java/com/simpleboard/board/auth/domain/common/vo/Role.java
@@ -1,4 +1,4 @@
-package com.simpleboard.board.auth.domain.token.vo;
+package com.simpleboard.board.auth.domain.common.vo;
 
 /**
  * <b>Role</b> Enum.

--- a/src/main/java/com/simpleboard/board/auth/domain/token/dto/LoginTokenIssueParam.java
+++ b/src/main/java/com/simpleboard/board/auth/domain/token/dto/LoginTokenIssueParam.java
@@ -1,6 +1,6 @@
 package com.simpleboard.board.auth.domain.token.dto;
 
-import com.simpleboard.board.auth.domain.token.vo.Role;
+import com.simpleboard.board.auth.domain.common.vo.Role;
 import lombok.Builder;
 
 /**
@@ -12,4 +12,4 @@ import lombok.Builder;
  * @since 1.0
  */
 @Builder
-public record LoginTokenIssueCommand(Long memberId, Role role) {}
+public record LoginTokenIssueParam(Long memberId, Role role) {}

--- a/src/main/java/com/simpleboard/board/auth/domain/token/dto/RefreshTokenRotationParam.java
+++ b/src/main/java/com/simpleboard/board/auth/domain/token/dto/RefreshTokenRotationParam.java
@@ -11,4 +11,4 @@ import lombok.Builder;
  * @since 1.0
  */
 @Builder
-public record RefreshTokenRotationCommand(String oldRefreshRaw) {}
+public record RefreshTokenRotationParam(String oldRefreshRaw) {}

--- a/src/main/java/com/simpleboard/board/auth/domain/token/dto/VerifyTokenIssueParam.java
+++ b/src/main/java/com/simpleboard/board/auth/domain/token/dto/VerifyTokenIssueParam.java
@@ -11,4 +11,4 @@ import java.time.Duration;
  * @domain request-dto
  * @since 1.0
  */
-public record VerifyTokenIssueCommand(VerifyPurpose purpose, String subject, Duration ttl) {}
+public record VerifyTokenIssueParam(VerifyPurpose purpose, String subject, Duration ttl) {}

--- a/src/main/java/com/simpleboard/board/auth/domain/token/exception/TokenTypeException.java
+++ b/src/main/java/com/simpleboard/board/auth/domain/token/exception/TokenTypeException.java
@@ -1,0 +1,12 @@
+package com.simpleboard.board.auth.domain.token.exception;
+
+import com.simpleboard.board.global.exception.ErrorCode;
+import com.simpleboard.board.global.exception.ServiceException;
+
+public class TokenTypeException extends ServiceException {
+  private static final ErrorCode ERROR_CODE = ErrorCode.INTERNAL_ERROR;
+
+  public TokenTypeException() {
+    super(ERROR_CODE);
+  }
+}

--- a/src/main/java/com/simpleboard/board/auth/domain/token/repository/MemberUUIDRepository.java
+++ b/src/main/java/com/simpleboard/board/auth/domain/token/repository/MemberUUIDRepository.java
@@ -28,4 +28,13 @@ public interface MemberUUIDRepository {
    * @since 1.0
    */
   Optional<Long> getMemberId(String UUID);
+
+  /**
+   * <b>UUID 재발급</b>
+   *
+   * <p>memberId에 대한 UUID 재발급을 진행한다
+   *
+   * @since 1.0
+   */
+  String updateUUID(Long memberId);
 }

--- a/src/main/java/com/simpleboard/board/auth/domain/token/repository/MemberUUIDRepository.java
+++ b/src/main/java/com/simpleboard/board/auth/domain/token/repository/MemberUUIDRepository.java
@@ -1,5 +1,7 @@
 package com.simpleboard.board.auth.domain.token.repository;
 
+import java.util.Optional;
+
 /**
  * <b>MemberUUIDRepository</b> Repository.
  *
@@ -25,5 +27,5 @@ public interface MemberUUIDRepository {
    *
    * @since 1.0
    */
-  Long getMemberId(String UUID);
+  Optional<Long> getMemberId(String UUID);
 }

--- a/src/main/java/com/simpleboard/board/auth/domain/token/service/TokenDomainService.java
+++ b/src/main/java/com/simpleboard/board/auth/domain/token/service/TokenDomainService.java
@@ -12,6 +12,7 @@ import com.simpleboard.board.auth.domain.token.repository.TokenBlacklistReposito
 import com.simpleboard.board.auth.domain.token.util.*;
 import com.simpleboard.board.auth.domain.token.vo.*;
 import java.time.Instant;
+import java.util.Date;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -76,9 +77,10 @@ public class TokenDomainService {
   public TokenPair issueLoginToken(LoginTokenIssueParam command) {
 
     Instant now = clockManager.now();
+    String uuid = uuidRepository.createOrGetUUID(command.memberId());
 
     // Create new token pair
-    return createLoginTokenPair(command.memberId(), command.role(), now, now);
+    return createLoginTokenPair(uuid, command.role(), now, now);
   }
 
   /**
@@ -94,6 +96,14 @@ public class TokenDomainService {
     Instant now = clockManager.now();
     TokenClaims claims = createVerifyClaims(command.subject(), command.purpose(), now);
     return tokenProvider.issueToken(claims);
+  }
+
+  public TokenClaims parseToken(String token) {
+    return tokenProvider.verifyAndParseToken(token);
+  }
+
+  public void validateToken(String tokenRaw) {
+    tokenProvider.validateToken(tokenRaw, Date.from(clockManager.now()));
   }
 
   /**
@@ -116,14 +126,15 @@ public class TokenDomainService {
     // Validate refresh token
     if (oldClaims.isExpired(now)) throw new RefreshTokenExpiredException();
     if (blacklistRepository.exists(oldClaims.tokenId()))
-      throw new RefreshTokenInvalidException(); // TODO: 이벤트 생성
+      throw new RefreshTokenInvalidException(); // TODO: 토큰 탈취 이벤트 생성
+    uuidRepository.getMemberId(oldClaims.subject()).orElseThrow(RefreshTokenInvalidException::new);
 
     // Enroll old token to blacklist
     blacklistRepository.save(oldClaims.tokenId(), oldClaims.expiredAt());
 
     // Create new token pair
     return createLoginTokenPair(
-        uuidRepository.getMemberId(oldClaims.subject()),
+        oldClaims.subject(), // memberUUID
         oldClaims.role(),
         now,
         oldClaims.issueAt());
@@ -148,11 +159,11 @@ public class TokenDomainService {
     blacklistRepository.save(claims.tokenId(), claims.expiredAt());
   }
 
-  private TokenClaims createAccessClaims(Long memberId, Role role, Instant now) {
+  private TokenClaims createAccessClaims(String memberUUID, Role role, Instant now) {
     return TokenClaims.builder()
         .tokenId(idGenerator.newTokenId())
         .tokenPurpose(TokenPurpose.ACCESS)
-        .subject(uuidRepository.createOrGetUUID(memberId))
+        .subject(memberUUID)
         .role(role)
         .audience(accessAudience)
         .issuer(issuer)
@@ -161,11 +172,11 @@ public class TokenDomainService {
         .build();
   }
 
-  private TokenClaims createRefreshClaims(Long memberId, Role role, Instant now) {
+  private TokenClaims createRefreshClaims(String memberUUID, Role role, Instant now) {
     return TokenClaims.builder()
         .tokenId(idGenerator.newTokenId())
         .tokenPurpose(TokenPurpose.REFRESH)
-        .subject(uuidRepository.createOrGetUUID(memberId))
+        .subject(memberUUID)
         .role(role)
         .audience(refreshAudience)
         .issuer(issuer)
@@ -188,11 +199,11 @@ public class TokenDomainService {
   }
 
   private TokenPair createLoginTokenPair(
-      Long memberId, Role role, Instant accessTokenIssueTime, Instant refreshTokenIssueTime) {
+      String memberUUID, Role role, Instant accessTokenIssueTime, Instant refreshTokenIssueTime) {
     Token accessToken =
-        tokenProvider.issueToken(createAccessClaims(memberId, role, accessTokenIssueTime));
+        tokenProvider.issueToken(createAccessClaims(memberUUID, role, accessTokenIssueTime));
     Token newRefreshToken =
-        tokenProvider.issueToken(createRefreshClaims(memberId, role, refreshTokenIssueTime));
+        tokenProvider.issueToken(createRefreshClaims(memberUUID, role, refreshTokenIssueTime));
 
     return TokenPair.builder().access(accessToken).refresh(newRefreshToken).build();
   }

--- a/src/main/java/com/simpleboard/board/auth/domain/token/service/TokenDomainService.java
+++ b/src/main/java/com/simpleboard/board/auth/domain/token/service/TokenDomainService.java
@@ -1,8 +1,9 @@
 package com.simpleboard.board.auth.domain.token.service;
 
-import com.simpleboard.board.auth.domain.token.dto.LoginTokenIssueCommand;
-import com.simpleboard.board.auth.domain.token.dto.RefreshTokenRotationCommand;
-import com.simpleboard.board.auth.domain.token.dto.VerifyTokenIssueCommand;
+import com.simpleboard.board.auth.domain.common.vo.Role;
+import com.simpleboard.board.auth.domain.token.dto.LoginTokenIssueParam;
+import com.simpleboard.board.auth.domain.token.dto.RefreshTokenRotationParam;
+import com.simpleboard.board.auth.domain.token.dto.VerifyTokenIssueParam;
 import com.simpleboard.board.auth.domain.token.exception.RefreshTokenEnrollBlacklistException;
 import com.simpleboard.board.auth.domain.token.exception.RefreshTokenExpiredException;
 import com.simpleboard.board.auth.domain.token.exception.RefreshTokenInvalidException;
@@ -72,7 +73,7 @@ public class TokenDomainService {
    * @return Access/Refresh TokenPair
    * @since 1.0
    */
-  public TokenPair issueLoginToken(LoginTokenIssueCommand command) {
+  public TokenPair issueLoginToken(LoginTokenIssueParam command) {
 
     Instant now = clockManager.now();
 
@@ -89,7 +90,7 @@ public class TokenDomainService {
    * @return Verify 토큰
    * @since 1.0
    */
-  public Token issueVerifyToken(VerifyTokenIssueCommand command) {
+  public Token issueVerifyToken(VerifyTokenIssueParam command) {
     Instant now = clockManager.now();
     TokenClaims claims = createVerifyClaims(command.subject(), command.purpose(), now);
     return tokenProvider.issueToken(claims);
@@ -106,7 +107,7 @@ public class TokenDomainService {
    * @throws RefreshTokenInvalidException 블랙리스트 존재 등 무효
    * @since 1.0
    */
-  public TokenPair rotateRefreshToken(RefreshTokenRotationCommand command) {
+  public TokenPair rotateRefreshToken(RefreshTokenRotationParam command) {
     Instant now = clockManager.now();
 
     TokenClaims oldClaims = tokenProvider.verifyAndParseToken(command.oldRefreshRaw());

--- a/src/main/java/com/simpleboard/board/auth/domain/token/service/TokenTTLPolicy.java
+++ b/src/main/java/com/simpleboard/board/auth/domain/token/service/TokenTTLPolicy.java
@@ -1,6 +1,6 @@
 package com.simpleboard.board.auth.domain.token.service;
 
-import com.simpleboard.board.auth.domain.token.vo.Role;
+import com.simpleboard.board.auth.domain.common.vo.Role;
 import com.simpleboard.board.auth.domain.token.vo.VerifyPurpose;
 import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/simpleboard/board/auth/domain/token/util/TokenProvider.java
+++ b/src/main/java/com/simpleboard/board/auth/domain/token/util/TokenProvider.java
@@ -2,6 +2,7 @@ package com.simpleboard.board.auth.domain.token.util;
 
 import com.simpleboard.board.auth.domain.token.vo.Token;
 import com.simpleboard.board.auth.domain.token.vo.TokenClaims;
+import java.util.Date;
 
 /**
  * <b>TokenProvider</b> Port.
@@ -29,4 +30,6 @@ public interface TokenProvider {
    * @since 1.0
    */
   TokenClaims verifyAndParseToken(String token);
+
+  void validateToken(String token, Date now);
 }

--- a/src/main/java/com/simpleboard/board/auth/domain/token/vo/TokenClaims.java
+++ b/src/main/java/com/simpleboard/board/auth/domain/token/vo/TokenClaims.java
@@ -17,7 +17,7 @@ public record TokenClaims(
     String tokenId,
     TokenPurpose tokenPurpose,
     VerifyPurpose verifyPurpose,
-    String subject,
+    String subject, // login 토큰의 경우 memberUUID, verify token의 경우 verify 대상(email, nickname 등)
     Role role,
     String audience,
     String issuer,

--- a/src/main/java/com/simpleboard/board/auth/domain/token/vo/TokenClaims.java
+++ b/src/main/java/com/simpleboard/board/auth/domain/token/vo/TokenClaims.java
@@ -1,5 +1,6 @@
 package com.simpleboard.board.auth.domain.token.vo;
 
+import com.simpleboard.board.auth.domain.common.vo.Role;
 import java.time.Instant;
 import lombok.Builder;
 

--- a/src/test/java/com/simpleboard/board/auth/domain/token/service/TokenDomainServiceTest.java
+++ b/src/test/java/com/simpleboard/board/auth/domain/token/service/TokenDomainServiceTest.java
@@ -5,9 +5,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import com.simpleboard.board.auth.domain.token.dto.LoginTokenIssueCommand;
-import com.simpleboard.board.auth.domain.token.dto.RefreshTokenRotationCommand;
-import com.simpleboard.board.auth.domain.token.dto.VerifyTokenIssueCommand;
+import com.simpleboard.board.auth.domain.common.vo.Role;
+import com.simpleboard.board.auth.domain.token.dto.LoginTokenIssueParam;
+import com.simpleboard.board.auth.domain.token.dto.RefreshTokenRotationParam;
+import com.simpleboard.board.auth.domain.token.dto.VerifyTokenIssueParam;
 import com.simpleboard.board.auth.domain.token.exception.RefreshTokenEnrollBlacklistException;
 import com.simpleboard.board.auth.domain.token.exception.RefreshTokenExpiredException;
 import com.simpleboard.board.auth.domain.token.exception.RefreshTokenInvalidException;
@@ -16,7 +17,6 @@ import com.simpleboard.board.auth.domain.token.repository.TokenBlacklistReposito
 import com.simpleboard.board.auth.domain.token.util.ClockManager;
 import com.simpleboard.board.auth.domain.token.util.IdGenerator;
 import com.simpleboard.board.auth.domain.token.util.TokenProvider;
-import com.simpleboard.board.auth.domain.token.vo.Role;
 import com.simpleboard.board.auth.domain.token.vo.Token;
 import com.simpleboard.board.auth.domain.token.vo.TokenClaims;
 import com.simpleboard.board.auth.domain.token.vo.TokenPair;
@@ -87,8 +87,7 @@ class TokenDomainServiceTest {
             .build();
     when(tokenProvider.issueToken(any(TokenClaims.class))).thenReturn(dummyAccess, dummyRefresh);
 
-    LoginTokenIssueCommand cmd =
-        LoginTokenIssueCommand.builder().memberId(memberId).role(role).build();
+    LoginTokenIssueParam cmd = LoginTokenIssueParam.builder().memberId(memberId).role(role).build();
 
     // when
     TokenPair result = service.issueLoginToken(cmd);
@@ -119,7 +118,7 @@ class TokenDomainServiceTest {
             .build();
     when(tokenProvider.issueToken(any(TokenClaims.class))).thenReturn(dummy);
 
-    VerifyTokenIssueCommand cmd = new VerifyTokenIssueCommand(purpose, subject, ttl);
+    VerifyTokenIssueParam cmd = new VerifyTokenIssueParam(purpose, subject, ttl);
 
     // when
     Token result = service.issueVerifyToken(cmd);
@@ -169,8 +168,7 @@ class TokenDomainServiceTest {
             .build();
     when(tokenProvider.issueToken(any(TokenClaims.class))).thenReturn(dummyA, dummyR);
 
-    RefreshTokenRotationCommand cmd =
-        RefreshTokenRotationCommand.builder().oldRefreshRaw(oldRaw).build();
+    RefreshTokenRotationParam cmd = RefreshTokenRotationParam.builder().oldRefreshRaw(oldRaw).build();
 
     // when
     TokenPair result = service.rotateRefreshToken(cmd);
@@ -198,8 +196,7 @@ class TokenDomainServiceTest {
     when(clockManager.now()).thenReturn(now);
     when(tokenProvider.verifyAndParseToken(oldRaw)).thenReturn(oldClaims);
 
-    RefreshTokenRotationCommand cmd =
-        RefreshTokenRotationCommand.builder().oldRefreshRaw(oldRaw).build();
+    RefreshTokenRotationParam cmd = RefreshTokenRotationParam.builder().oldRefreshRaw(oldRaw).build();
 
     // when & then
     assertThatThrownBy(() -> service.rotateRefreshToken(cmd))
@@ -223,8 +220,7 @@ class TokenDomainServiceTest {
     when(clockManager.now()).thenReturn(now);
     when(tokenProvider.verifyAndParseToken(oldRaw)).thenReturn(oldClaims);
 
-    RefreshTokenRotationCommand cmd =
-        RefreshTokenRotationCommand.builder().oldRefreshRaw(oldRaw).build();
+    RefreshTokenRotationParam cmd = RefreshTokenRotationParam.builder().oldRefreshRaw(oldRaw).build();
 
     // when & then
     assertThatThrownBy(() -> service.rotateRefreshToken(cmd))
@@ -249,8 +245,7 @@ class TokenDomainServiceTest {
     when(tokenProvider.verifyAndParseToken(oldRaw)).thenReturn(oldClaims);
     when(blacklistRepository.exists("id")).thenReturn(true);
 
-    RefreshTokenRotationCommand cmd =
-        RefreshTokenRotationCommand.builder().oldRefreshRaw(oldRaw).build();
+    RefreshTokenRotationParam cmd = RefreshTokenRotationParam.builder().oldRefreshRaw(oldRaw).build();
 
     // when & then
     assertThatThrownBy(() -> service.rotateRefreshToken(cmd))

--- a/src/test/java/com/simpleboard/board/auth/domain/token/service/TokenDomainServiceTest.java
+++ b/src/test/java/com/simpleboard/board/auth/domain/token/service/TokenDomainServiceTest.java
@@ -24,6 +24,7 @@ import com.simpleboard.board.auth.domain.token.vo.TokenPurpose;
 import com.simpleboard.board.auth.domain.token.vo.VerifyPurpose;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -148,7 +149,7 @@ class TokenDomainServiceTest {
     when(tokenProvider.verifyAndParseToken(oldRaw)).thenReturn(oldClaims);
     when(blacklistRepository.exists("oldId")).thenReturn(false);
     doNothing().when(blacklistRepository).save("oldId", oldClaims.expiredAt());
-    when(uuidRepository.getMemberId("uuid")).thenReturn(99L);
+    when(uuidRepository.getMemberId("uuid")).thenReturn(Optional.of(99L));
     when(idGenerator.newTokenId()).thenReturn("newAccessId", "newRefreshId");
     when(ttlPolicy.accessTtlFor(Role.ADMIN)).thenReturn(Duration.ofMinutes(5));
     when(ttlPolicy.refreshTtlFor(Role.ADMIN)).thenReturn(Duration.ofDays(15));
@@ -168,7 +169,8 @@ class TokenDomainServiceTest {
             .build();
     when(tokenProvider.issueToken(any(TokenClaims.class))).thenReturn(dummyA, dummyR);
 
-    RefreshTokenRotationParam cmd = RefreshTokenRotationParam.builder().oldRefreshRaw(oldRaw).build();
+    RefreshTokenRotationParam cmd =
+        RefreshTokenRotationParam.builder().oldRefreshRaw(oldRaw).build();
 
     // when
     TokenPair result = service.rotateRefreshToken(cmd);
@@ -196,7 +198,8 @@ class TokenDomainServiceTest {
     when(clockManager.now()).thenReturn(now);
     when(tokenProvider.verifyAndParseToken(oldRaw)).thenReturn(oldClaims);
 
-    RefreshTokenRotationParam cmd = RefreshTokenRotationParam.builder().oldRefreshRaw(oldRaw).build();
+    RefreshTokenRotationParam cmd =
+        RefreshTokenRotationParam.builder().oldRefreshRaw(oldRaw).build();
 
     // when & then
     assertThatThrownBy(() -> service.rotateRefreshToken(cmd))
@@ -220,7 +223,8 @@ class TokenDomainServiceTest {
     when(clockManager.now()).thenReturn(now);
     when(tokenProvider.verifyAndParseToken(oldRaw)).thenReturn(oldClaims);
 
-    RefreshTokenRotationParam cmd = RefreshTokenRotationParam.builder().oldRefreshRaw(oldRaw).build();
+    RefreshTokenRotationParam cmd =
+        RefreshTokenRotationParam.builder().oldRefreshRaw(oldRaw).build();
 
     // when & then
     assertThatThrownBy(() -> service.rotateRefreshToken(cmd))
@@ -245,7 +249,8 @@ class TokenDomainServiceTest {
     when(tokenProvider.verifyAndParseToken(oldRaw)).thenReturn(oldClaims);
     when(blacklistRepository.exists("id")).thenReturn(true);
 
-    RefreshTokenRotationParam cmd = RefreshTokenRotationParam.builder().oldRefreshRaw(oldRaw).build();
+    RefreshTokenRotationParam cmd =
+        RefreshTokenRotationParam.builder().oldRefreshRaw(oldRaw).build();
 
     // when & then
     assertThatThrownBy(() -> service.rotateRefreshToken(cmd))

--- a/src/test/java/com/simpleboard/board/auth/domain/token/service/TokenTTLPolicyTest.java
+++ b/src/test/java/com/simpleboard/board/auth/domain/token/service/TokenTTLPolicyTest.java
@@ -2,7 +2,7 @@ package com.simpleboard.board.auth.domain.token.service;
 
 import static org.assertj.core.api.Assertions.*;
 
-import com.simpleboard.board.auth.domain.token.vo.Role;
+import com.simpleboard.board.auth.domain.common.vo.Role;
 import com.simpleboard.board.auth.domain.token.vo.VerifyPurpose;
 import java.time.Duration;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
<!-- 제목은 `[도메인] PR 제목`으로 작성해주세요. (ex) [User] 소셜 로그인 필터 리팩토링 -->
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- Token 탈취 시 특정 회원에 대한 기발급 토큰 블락 기능 추가

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->
Blacklist 레포지토리에 유저의 아이디를 추가하여 블락하는 대신, UUID 레포지토리 조회시 에러가 발생하도록 하였습니다.
이런 방법을 사용했을 때 문제 생길만한 부분 생각나는거 있으면 말해주세요.
탈취 이벤트는 아직 미개발 상태입니다.

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed #75 
