### PR TITLE
[Auth] 인증 관련 application 계층 개발

### DIFF
--- a/src/main/java/com/simpleboard/board/auth/application/dto/request/EmailMemberRegisterCommand.java
+++ b/src/main/java/com/simpleboard/board/auth/application/dto/request/EmailMemberRegisterCommand.java
@@ -1,0 +1,7 @@
+package com.simpleboard.board.auth.application.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record EmailMemberRegisterCommand(
+    String emailTokenRaw, String nicknameTokenRaw, String password, String gender, int birthYear) {}

--- a/src/main/java/com/simpleboard/board/auth/application/dto/request/OAuthMemberRegisterCommand.java
+++ b/src/main/java/com/simpleboard/board/auth/application/dto/request/OAuthMemberRegisterCommand.java
@@ -1,0 +1,6 @@
+package com.simpleboard.board.auth.application.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record OAuthMemberRegisterCommand(String nicknameTokenRaw, String gender, int birthYear) {}

--- a/src/main/java/com/simpleboard/board/auth/application/exception/EmailCodeException.java
+++ b/src/main/java/com/simpleboard/board/auth/application/exception/EmailCodeException.java
@@ -1,0 +1,12 @@
+package com.simpleboard.board.auth.application.exception;
+
+import com.simpleboard.board.global.exception.ErrorCode;
+import com.simpleboard.board.global.exception.ServiceException;
+
+public class EmailCodeException extends ServiceException {
+  private static final ErrorCode ERROR_CODE = ErrorCode.EMAIL_CODE_MISMATCH;
+
+  public EmailCodeException() {
+    super(ERROR_CODE);
+  }
+}

--- a/src/main/java/com/simpleboard/board/auth/application/exception/EmailConflictException.java
+++ b/src/main/java/com/simpleboard/board/auth/application/exception/EmailConflictException.java
@@ -1,0 +1,12 @@
+package com.simpleboard.board.auth.application.exception;
+
+import com.simpleboard.board.global.exception.ErrorCode;
+import com.simpleboard.board.global.exception.ServiceException;
+
+public class EmailConflictException extends ServiceException {
+  private static final ErrorCode ERROR_CODE = ErrorCode.EMAIL_CONFLICT;
+
+  public EmailConflictException() {
+    super(ERROR_CODE);
+  }
+}

--- a/src/main/java/com/simpleboard/board/auth/application/exception/NicknameConflictException.java
+++ b/src/main/java/com/simpleboard/board/auth/application/exception/NicknameConflictException.java
@@ -1,0 +1,11 @@
+package com.simpleboard.board.auth.application.exception;
+
+import com.simpleboard.board.global.exception.ErrorCode;
+import com.simpleboard.board.global.exception.ServiceException;
+
+public class NicknameConflictException extends ServiceException {
+    private static final ErrorCode ERROR_CODE = ErrorCode.NICKNAME_CONFLICT;
+    public NicknameConflictException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/simpleboard/board/auth/application/exception/UserDisabledException.java
+++ b/src/main/java/com/simpleboard/board/auth/application/exception/UserDisabledException.java
@@ -1,0 +1,13 @@
+package com.simpleboard.board.auth.application.exception;
+
+import com.simpleboard.board.global.exception.ErrorCode;
+import com.simpleboard.board.global.exception.ServiceException;
+
+/** <b>Member의 상태가 Activate가 아닐 때 발생되는 Exception</b> */
+public class UserDisabledException extends ServiceException {
+  private static final ErrorCode ERROR_CODE = ErrorCode.USER_DEACTIVATED;
+
+  public UserDisabledException() {
+    super(ERROR_CODE);
+  }
+}

--- a/src/main/java/com/simpleboard/board/auth/application/exception/UserNotFoundException.java
+++ b/src/main/java/com/simpleboard/board/auth/application/exception/UserNotFoundException.java
@@ -1,0 +1,13 @@
+package com.simpleboard.board.auth.application.exception;
+
+import com.simpleboard.board.global.exception.ErrorCode;
+import com.simpleboard.board.global.exception.ServiceException;
+
+/** <b>로그인 및 Access 토큰 로딩시 해당하는 유저를 발견하지 못함</b> */
+public class UserNotFoundException extends ServiceException {
+  private static final ErrorCode ERROR_CODE = ErrorCode.USER_NOT_FOUND;
+
+  public UserNotFoundException() {
+    super(ERROR_CODE);
+  }
+}

--- a/src/main/java/com/simpleboard/board/auth/application/service/AuthPrincipal.java
+++ b/src/main/java/com/simpleboard/board/auth/application/service/AuthPrincipal.java
@@ -1,0 +1,71 @@
+package com.simpleboard.board.auth.application.service;
+
+import com.simpleboard.board.auth.domain.auth.entity.UserAuth;
+import com.simpleboard.board.auth.domain.auth.vo.RegisterType;
+import com.simpleboard.board.auth.domain.auth.vo.UserState;
+import com.simpleboard.board.auth.domain.common.vo.Role;
+import java.util.Collection;
+import java.util.List;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+/**
+ * <b>Security context에 주입될 Authentication 정보</b>
+ *
+ * <p>UserDetails 인터페이스를 구현
+ *
+ * <p>email 로그인, Access 토큰 파싱시 사용
+ */
+public class AuthPrincipal implements UserDetails {
+
+  @Getter private final Long userId;
+  @Getter private final Role role;
+  private final String password;
+  private final UserState userState;
+  private final RegisterType registerType;
+
+  public AuthPrincipal(UserAuth userAuth) {
+    this.userId = userAuth.getUserId();
+    this.password = userAuth.getPassword();
+    this.role = userAuth.getRole();
+    this.userState = userAuth.getUserState();
+    this.registerType = userAuth.getRegisterType();
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+  }
+
+  @Override
+  public String getUsername() {
+    return String.valueOf(userId);
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return userState == UserState.ACTIVE;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return userState == UserState.ACTIVE;
+  }
+}

--- a/src/main/java/com/simpleboard/board/auth/application/service/AuthPrincipalService.java
+++ b/src/main/java/com/simpleboard/board/auth/application/service/AuthPrincipalService.java
@@ -1,0 +1,56 @@
+package com.simpleboard.board.auth.application.service;
+
+import com.simpleboard.board.auth.domain.token.vo.TokenPair;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+/**
+ * <b>Authentication 응용 서비스 클래스</b>
+ *
+ * <p>Spring Security의 UserDetails를 implements한 AuthPrincipal 클래스와 관련된 일을 하는 응용 서비스
+ *
+ * <ul>
+ *   <li>AuthPrincipal에 대한 조회 및 검증
+ *   <li>AuthPrincipal을 통한 로그인 토큰 발급
+ * </ul>
+ *
+ * @domain application-service
+ * @transactional
+ */
+public interface AuthPrincipalService extends UserDetailsService {
+  /**
+   * <b>Email/password 로그인용 메서드</b>
+   *
+   * <p>email을 통해 UserAuth를 조회, AuthPrincipal을 로딩
+   *
+   * @since 1.0
+   */
+  public UserDetails loadUserByUsername(String email);
+
+  /**
+   * <b>OAuth 로그인용 메서드</b>
+   *
+   * <p>OAuth id를 통해 UserAuth를 조회, AuthPrincipal을 로딩
+   *
+   * @since 1.0
+   */
+  public UserDetails loadUserByOAuthId(String oAuthId);
+
+  /**
+   * <b>Access 토큰용 메서드</b>
+   *
+   * <p>Access 토큰을 파싱하여 AuthPrincipal을 로딩
+   *
+   * @since 1.0
+   */
+  public UserDetails loadUserByTokenRaw(String tokenRaw);
+
+  /**
+   * <b>로그인 토큰 페어 발행 메서드</b>
+   *
+   * <p>AuthPrincipal을 통해 로그인 토큰 페어를 발행
+   *
+   * @since 1.0
+   */
+  public TokenPair issueTokenPair(AuthPrincipal principal);
+}

--- a/src/main/java/com/simpleboard/board/auth/application/service/AuthPrincipalServiceImpl.java
+++ b/src/main/java/com/simpleboard/board/auth/application/service/AuthPrincipalServiceImpl.java
@@ -1,0 +1,75 @@
+package com.simpleboard.board.auth.application.service;
+
+import com.simpleboard.board.auth.application.exception.UserDisabledException;
+import com.simpleboard.board.auth.application.exception.UserNotFoundException;
+import com.simpleboard.board.auth.domain.auth.entity.UserAuth;
+import com.simpleboard.board.auth.domain.auth.repository.AuthCommandRepository;
+import com.simpleboard.board.auth.domain.auth.vo.UserState;
+import com.simpleboard.board.auth.domain.common.vo.Role;
+import com.simpleboard.board.auth.domain.token.dto.request.LoginTokenIssueParam;
+import com.simpleboard.board.auth.domain.token.dto.response.LoginTokenInfo;
+import com.simpleboard.board.auth.domain.token.service.TokenDomainService;
+import com.simpleboard.board.auth.domain.token.vo.TokenPair;
+import com.simpleboard.board.auth.domain.token.vo.TokenPurpose;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthPrincipalServiceImpl implements AuthPrincipalService {
+  private final TokenDomainService tokenDomainService;
+  private final AuthCommandRepository authCommandRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+
+    UserAuth userAuth =
+        authCommandRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+
+    validateUserAuth(userAuth);
+    return new AuthPrincipal(userAuth);
+  }
+
+  @Override
+  public UserDetails loadUserByOAuthId(String oAuthId) {
+    UserAuth userAuth =
+        authCommandRepository.findByOAuthId(oAuthId).orElseThrow(UserNotFoundException::new);
+
+    validateUserAuth(userAuth);
+    return new AuthPrincipal(userAuth);
+  }
+
+  @Override
+  public UserDetails loadUserByTokenRaw(String tokenRaw) {
+    LoginTokenInfo tokenInfo = tokenDomainService.validateAndParseLoginToken(tokenRaw);
+    if (!tokenInfo.tokenPurpose().equals(TokenPurpose.ACCESS))
+      throw new IllegalArgumentException("Invalid token");
+
+    UserAuth userAuth =
+        authCommandRepository
+            .findById(tokenInfo.memberId())
+            .orElseThrow(UserNotFoundException::new);
+
+    validateUserAuth(userAuth);
+    return new AuthPrincipal(userAuth);
+  }
+
+  @Override
+  public TokenPair issueTokenPair(AuthPrincipal principal) {
+
+    Long memberId = principal.getUserId();
+    Role role = principal.getRole();
+
+    return tokenDomainService.issueLoginToken(
+        LoginTokenIssueParam.builder().memberId(memberId).role(role).build());
+  }
+
+  private void validateUserAuth(UserAuth userAuth) {
+    // TODO: UserState 추가시 검증 로직 필요
+    if (!userAuth.getUserState().equals(UserState.ACTIVE)) {
+      throw new UserDisabledException();
+    }
+  }
+}

--- a/src/main/java/com/simpleboard/board/auth/application/service/TokenApplicationService.java
+++ b/src/main/java/com/simpleboard/board/auth/application/service/TokenApplicationService.java
@@ -1,0 +1,49 @@
+package com.simpleboard.board.auth.application.service;
+
+import com.simpleboard.board.auth.domain.token.vo.Token;
+import com.simpleboard.board.auth.domain.token.vo.TokenPair;
+import com.simpleboard.board.auth.domain.token.vo.VerifyPurpose;
+
+/**
+ * <b>Token과 관련된 기능을 수행하는 Application Service 클래스</b>
+ *
+ * <p>로그인 토큰의 발행은 AuthPrincipalService 에서 처리
+ *
+ * <p>AuthPrincipal과 상관없는 토큰 기능을 수행
+ */
+public interface TokenApplicationService {
+  /**
+   * <b>Refresh 토큰 Rotation 메서드</b>
+   *
+   * <p>토큰 validation 후, 기존 토큰을 비활성화, 새로운 로그인 토큰 페어 발행
+   *
+   * @since 1.0
+   */
+  TokenPair rotateRefreshToken(String refreshTokenRaw);
+
+  /**
+   * <b>Verify용 토큰 발행 메서드</b>
+   *
+   * @since 1.0
+   */
+  Token issueVerifyToken(String subject, VerifyPurpose purpose);
+
+  /**
+   * <b>로그아웃 등의 정상 동작 내 토큰 비활성화 메서드</b>
+   *
+   * @param tokenRaw
+   */
+  void enrollBlacklist(String tokenRaw);
+
+  /**
+   * <b>비정상 동작, 토큰 탈취 감지시 대응 메서드</b>
+   *
+   * <ul>
+   *   <li>토큰 비활성화
+   *   <li>유저 UUID 재발급
+   * </ul>
+   *
+   * @param tokenRaw
+   */
+  void blockSnatchedToken(String tokenRaw);
+}

--- a/src/main/java/com/simpleboard/board/auth/application/service/UserAuthCommandService.java
+++ b/src/main/java/com/simpleboard/board/auth/application/service/UserAuthCommandService.java
@@ -1,0 +1,50 @@
+package com.simpleboard.board.auth.application.service;
+
+import com.simpleboard.board.auth.application.dto.request.EmailMemberRegisterCommand;
+import com.simpleboard.board.auth.application.dto.request.OAuthMemberRegisterCommand;
+
+/**
+ * <b>UserAuth aggregate에 대한 응용 서비스 클래스</b>
+ *
+ * <ul>
+ *   <li>회원가입 시 UserAuth의 생성 & Member 도메인에 생성 이벤트 발송
+ *   <li>회원가입 과정에서 Auth aggregate에 대한 조회, 검증 수행
+ * </ul>
+ *
+ * @domain application-service
+ */
+public interface UserAuthCommandService {
+
+  /**
+   * <b>Email 회원가입을 수행하는 메서드</b>
+   *
+   * <ul>
+   *   <li>command에 존재하는 토큰 검증&파싱
+   *   <li>Auth aggregate 생성, 저장
+   *   <li>email Member 회원가입 이벤트 생성
+   * </ul>
+   *
+   * @param command 회원가입 command
+   */
+  public void emailMemberRegister(EmailMemberRegisterCommand command);
+
+  /**
+   * <b>OAuth 회원가입을 수행하는 메서드</b>
+   *
+   * <ul>
+   *   <li>command에 존재하는 토큰 검증&파싱
+   *   <li>Auth aggregate 생성, 저장
+   *   <li>OAuth Member 회원가입 이벤트 생성
+   * </ul>
+   *
+   * @param command 회원가입 command
+   */
+  public void oAuthMemberRegister(OAuthMemberRegisterCommand command);
+
+  /**
+   * <b>회원 탈퇴 응용서비스</b>
+   *
+   * <p>Auth aggregate를 비활성화 후 이벤트 생성
+   */
+  public void deactivateAccount(Long memberId);
+}

--- a/src/main/java/com/simpleboard/board/auth/application/service/VerificationCommandService.java
+++ b/src/main/java/com/simpleboard/board/auth/application/service/VerificationCommandService.java
@@ -1,0 +1,44 @@
+package com.simpleboard.board.auth.application.service;
+
+import com.simpleboard.board.auth.application.exception.EmailCodeException;
+import com.simpleboard.board.auth.application.exception.EmailConflictException;
+import com.simpleboard.board.auth.application.exception.NicknameConflictException;
+import com.simpleboard.board.auth.domain.token.vo.Token;
+
+/**
+ * <b>여러 Verification을 처리하는 메서드</b>
+ */
+public interface VerificationCommandService {
+
+  /**
+   * <b>Email 회원가입 시 Email 사용 가능 검증 메서드</b>
+   *
+   * <p>email이 사용 가능한지 검증 후 email에 코드 발송
+   *
+   * @exception EmailConflictException 이미 가입된 이메일
+   * @param email Code를 발송할 email
+   */
+  public void sendEmailCode(String email);
+
+  /**
+   * <b>Email 회원가입 시 Email 사용 가능 검증 메서드</b>
+   *
+   * <p>email에 발송한 코드를 검증 후 코드 일치 시 lock & 토큰 반환
+   *
+   * @exception EmailCodeException 코드 불일치
+   * @param email 검증 email
+   * @return email 토큰
+   */
+  public Token verifyEmailCode(String email, String code);
+
+  /**
+   * <b>nickname verification 메서드</b>
+   *
+   * <p>대상 nickname이 사용 가능한 닉네임인지 확인 후 사용 가능하다면 lock & 토큰 반환
+   *
+   * @exception NicknameConflictException nickname이 이미 사용중임
+   * @param nickname 검증 nickname
+   * @return nickname 토큰
+   */
+  public Token verifyNickname(String nickname);
+}

--- a/src/main/java/com/simpleboard/board/global/exception/ErrorCode.java
+++ b/src/main/java/com/simpleboard/board/global/exception/ErrorCode.java
@@ -41,6 +41,12 @@ public enum ErrorCode {
   // Auth
   USER_DEACTIVATED(HttpStatus.BAD_REQUEST, "400_USER_DEACTIVATED", "유저의 계정이 비활성화 상태입니다."),
   TOKEN_BLOCKED(HttpStatus.UNAUTHORIZED, "401_TOKEN_BLOCKED", "비활성화된 토큰입니다."),
+  TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "401_TOKEN_EXPIRED", "만료된 토큰입니다."),
+  TOKEN_PARSE_FAIL(HttpStatus.BAD_REQUEST, "400_TOKEN_ERROR", "유효하지 않은 토큰입니다."),
+  EMAIL_CONFLICT(HttpStatus.CONFLICT, "409_EMAIL_CONFLICT", "이미 가입된 email입니다."),
+  NICKNAME_CONFLICT(HttpStatus.CONFLICT, "409_NICKNAME_CONFLICT", "이미 사용중인 nickname입니다."),
+  EMAIL_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "400_EMAIL_CODE_MISMATCH", "email 코드가 일치하지 않습니다."),
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "404_USER_NOT_FOUND", "일치하는 유저가 존재하지 않습니다."),
 
   /* Internal Error */
   INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500_INTERNAL", "서버 내부 오류가 발생했습니다."),


### PR DESCRIPTION
<!-- 제목은 `[도메인] PR 제목`으로 작성해주세요. (ex) [User] 소셜 로그인 필터 리팩토링 -->
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- Spring security에서 사용되는 UserDetails, UserDetailsService 구현체 개발
- Token, UserAuth aggregate 응용 서비스 인터페이스 정의

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->
UserDetails, UserDetailsService의 구현체인 AuthPrincipal과 AuthPrincipalService를 application 계층에 두었습니다.
당연하지만 두 클래스는 Spring security에 의존성이 있습니다. 
최대한 의존성이 없도록 설계해보려 했는데 지금 구조가 저의 한계더라구요.
혹시 좋은 아이디어가 있으시다면 제안 부탁드립니다.

또, 인터페이스들의 구조를 보시고 OAuth 로그인 개발에 문제가 될 것 같은 부분이 있다면 말씀해주세요.

### 📝 메모
<!-- PR 관련 전달사항이 있다면 이곳에 작성해주세요. -->
나머지 응용 서비스들을 인터페이스로만 정의한 이유는, 우선 인증 파트를 필터까지 완성하고 나머지 응용서비스들을 구현해도 괜찮다 생각했기 때문입니다.
응용 서비스 중 일부는 OAuth 로그인과 함께 개발해야 하기도 하구요.

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
#79 
