### PR TITLE
[Board] Post 상세조회 application, infra 계층 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 
 	// DB
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation "org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3"
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	// AOP

--- a/src/main/java/com/simpleboard/board/board/application/converter/PostQueryServiceRepoConverter.java
+++ b/src/main/java/com/simpleboard/board/board/application/converter/PostQueryServiceRepoConverter.java
@@ -1,0 +1,69 @@
+package com.simpleboard.board.board.application.converter;
+
+import com.simpleboard.board.board.application.dto.request.PostDetailsQuery;
+import com.simpleboard.board.board.application.dto.response.AuthorSummary;
+import com.simpleboard.board.board.application.dto.response.PostDetailsQueryResult;
+import com.simpleboard.board.board.application.query.PostDetailsCriteria;
+import com.simpleboard.board.board.application.query.PostDetailsReadModel;
+import com.simpleboard.board.board.domain.post.vo.PostTypeEnum;
+import org.springframework.stereotype.Component;
+
+/** <b>Post query service <-> repository 컨버터</b> */
+@Component
+public class PostQueryServiceRepoConverter {
+
+  /**************************
+   * Request converter
+   * Service -> Repository
+   **************************/
+
+  public PostDetailsCriteria getCriteria(PostDetailsQuery query) {
+    return PostDetailsCriteria.builder()
+        .type(query.visitor().type())
+        .vId(query.visitor().vId())
+        .memberId(query.visitor().memberId())
+        .postId(query.postId())
+        .build();
+  }
+
+  /**************************
+   * Response converter
+   * Service <- Repository
+   **************************/
+
+  public PostDetailsQueryResult getQueryResult(PostDetailsReadModel readModel) {
+    if (!readModel.postType().equals(PostTypeEnum.GUEST)) throw new IllegalArgumentException();
+    return PostDetailsQueryResult.builder()
+        .postId(readModel.postId())
+        .postType(readModel.postType())
+        .title(readModel.title())
+        .content(readModel.content())
+        .viewCount(readModel.viewCount())
+        .isLiked(readModel.isLiked())
+        .likeCount(readModel.likeCount())
+        .updatedAt(readModel.updatedAt())
+        .createdAt(readModel.createdAt())
+        .hashTags(readModel.hashTags())
+        .authorNickname(readModel.nickname())
+        .build();
+  }
+
+  public PostDetailsQueryResult getQueryResult(
+      PostDetailsReadModel readModel, AuthorSummary authorSummary) {
+    if (!readModel.postType().equals(PostTypeEnum.MEMBER)) throw new IllegalArgumentException();
+    return PostDetailsQueryResult.builder()
+        .postId(readModel.postId())
+        .postType(readModel.postType())
+        .title(readModel.title())
+        .content(readModel.content())
+        .viewCount(readModel.viewCount())
+        .isLiked(readModel.isLiked())
+        .likeCount(readModel.likeCount())
+        .updatedAt(readModel.updatedAt())
+        .createdAt(readModel.createdAt())
+        .hashTags(readModel.hashTags())
+        .authorId(authorSummary.authorId())
+        .authorNickname(authorSummary.nickname())
+        .build();
+  }
+}

--- a/src/main/java/com/simpleboard/board/board/application/dto/request/PostDetailsQuery.java
+++ b/src/main/java/com/simpleboard/board/board/application/dto/request/PostDetailsQuery.java
@@ -1,0 +1,14 @@
+package com.simpleboard.board.board.application.dto.request;
+
+import com.simpleboard.board.board.domain.common.vo.Visitor;
+import lombok.Builder;
+
+/**
+ * <b>Post 상세 조회 요청 모델</b>
+ *
+ * <p>Req: presentation -> application
+ *
+ * @domain request-dto
+ */
+@Builder
+public record PostDetailsQuery(Visitor visitor, Long postId) {}

--- a/src/main/java/com/simpleboard/board/board/application/dto/response/AuthorSummary.java
+++ b/src/main/java/com/simpleboard/board/board/application/dto/response/AuthorSummary.java
@@ -1,0 +1,13 @@
+package com.simpleboard.board.board.application.dto.response;
+
+import lombok.Builder;
+
+/**
+ * Post Author 정보 응답 모델.
+ *
+ * <p>Res: Post query service <- Member B.C
+ *
+ * @domain response-dto
+ */
+@Builder
+public record AuthorSummary(Long authorId, String nickname) {}

--- a/src/main/java/com/simpleboard/board/board/application/dto/response/PostDetailsQueryResult.java
+++ b/src/main/java/com/simpleboard/board/board/application/dto/response/PostDetailsQueryResult.java
@@ -1,0 +1,27 @@
+package com.simpleboard.board.board.application.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * <b>Post 단건 조회 응답 모델</b>
+ *
+ * <p>Res: presentation <- application
+ *
+ * @domain response-dto
+ */
+@Builder
+public record PostDetailsQueryResult(
+    Long postId,
+    String postType,
+    String title,
+    String content,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    List<String> hashTags,
+    Long viewCount,
+    Integer likeCount,
+    Boolean isLiked,
+    Long authorId,
+    String authorNickname) {}

--- a/src/main/java/com/simpleboard/board/board/application/query/PostDetailsCriteria.java
+++ b/src/main/java/com/simpleboard/board/board/application/query/PostDetailsCriteria.java
@@ -1,0 +1,14 @@
+package com.simpleboard.board.board.application.query;
+
+import com.simpleboard.board.board.domain.common.vo.VisitorType;
+import lombok.Builder;
+
+/**
+ * Post 상세 조회 조건 DTO
+ *
+ * <p>Req: service -> respository
+ *
+ * @domain request-dto
+ */
+@Builder
+public record PostDetailsCriteria(VisitorType type, String vId, Long memberId, Long postId) {}

--- a/src/main/java/com/simpleboard/board/board/application/query/PostDetailsReadModel.java
+++ b/src/main/java/com/simpleboard/board/board/application/query/PostDetailsReadModel.java
@@ -1,0 +1,27 @@
+package com.simpleboard.board.board.application.query;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * Post 상세 조회 반환 DTO
+ *
+ * <p>Res: respotiroy <- service
+ *
+ * @domain response-dto
+ */
+@Builder
+public record PostDetailsReadModel(
+    Long postId,
+    String postType,
+    String title,
+    String content,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    List<String> hashTags,
+    Long viewCount,
+    Integer likeCount,
+    Boolean isLiked,
+    Long authorId,
+    String nickname) {}

--- a/src/main/java/com/simpleboard/board/board/application/query/PostQueryRepository.java
+++ b/src/main/java/com/simpleboard/board/board/application/query/PostQueryRepository.java
@@ -1,0 +1,13 @@
+package com.simpleboard.board.board.application.query;
+
+/**
+ * Post 조회용 저장소 포트.
+ *
+ * <p>Post 관련 조회 인터페이스
+ *
+ * @domain repository-port
+ */
+public interface PostQueryRepository {
+
+  PostDetailsReadModel getPostDetails(PostDetailsCriteria criteria);
+}

--- a/src/main/java/com/simpleboard/board/board/application/service/MemberFetchService.java
+++ b/src/main/java/com/simpleboard/board/board/application/service/MemberFetchService.java
@@ -1,0 +1,12 @@
+package com.simpleboard.board.board.application.service;
+
+import com.simpleboard.board.board.application.dto.response.AuthorSummary;
+
+/**
+ * <b>Member Data 조회 서비스 클래스</b>
+ *
+ * <p>Member B.C의 internal API를 통해 데이터를 Fetch
+ */
+public interface MemberFetchService {
+  AuthorSummary getAuthorSummary(Long authorId);
+}

--- a/src/main/java/com/simpleboard/board/board/application/service/PostQueryService.java
+++ b/src/main/java/com/simpleboard/board/board/application/service/PostQueryService.java
@@ -1,0 +1,16 @@
+package com.simpleboard.board.board.application.service;
+
+import com.simpleboard.board.board.application.dto.request.PostDetailsQuery;
+import com.simpleboard.board.board.application.dto.response.PostDetailsQueryResult;
+
+/**
+ * <b>Post 조회 유스케이스</b>
+ *
+ * <p>Post 상세조회, 목록조회 수행
+ *
+ * @domain application-service
+ * @transactional
+ */
+public interface PostQueryService {
+  PostDetailsQueryResult getPostDetails(PostDetailsQuery query);
+}

--- a/src/main/java/com/simpleboard/board/board/application/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/simpleboard/board/board/application/service/PostQueryServiceImpl.java
@@ -1,0 +1,33 @@
+package com.simpleboard.board.board.application.service;
+
+import com.simpleboard.board.board.application.converter.PostQueryServiceRepoConverter;
+import com.simpleboard.board.board.application.dto.request.PostDetailsQuery;
+import com.simpleboard.board.board.application.dto.response.AuthorSummary;
+import com.simpleboard.board.board.application.dto.response.PostDetailsQueryResult;
+import com.simpleboard.board.board.application.query.PostDetailsReadModel;
+import com.simpleboard.board.board.application.query.PostQueryRepository;
+import com.simpleboard.board.board.domain.post.exception.PostNotFoundException;
+import com.simpleboard.board.board.domain.post.vo.PostTypeEnum;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostQueryServiceImpl implements PostQueryService {
+
+  private final PostQueryRepository postQueryRepository;
+  private final MemberFetchService memberFetchService;
+  private final PostQueryServiceRepoConverter converter;
+
+  @Override
+  public PostDetailsQueryResult getPostDetails(PostDetailsQuery query) {
+    PostDetailsReadModel readModel =
+        postQueryRepository.getPostDetails(converter.getCriteria(query));
+    if (readModel == null) throw new PostNotFoundException();
+    if (readModel.postType().equals(PostTypeEnum.MEMBER)) {
+      AuthorSummary summary = memberFetchService.getAuthorSummary(readModel.authorId());
+      return converter.getQueryResult(readModel, summary);
+    }
+    return converter.getQueryResult(readModel);
+  }
+}

--- a/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/converter/PostQueryConverter.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/converter/PostQueryConverter.java
@@ -1,0 +1,52 @@
+package com.simpleboard.board.board.infrastructure.mybatis.converter;
+
+import com.simpleboard.board.board.application.query.PostDetailsCriteria;
+import com.simpleboard.board.board.application.query.PostDetailsReadModel;
+import com.simpleboard.board.board.infrastructure.mybatis.mapper.PostDetailsCondition;
+import com.simpleboard.board.board.infrastructure.mybatis.mapper.PostDetailsData;
+import java.util.List;
+
+/**
+ * <b>Repository <-> Mapper converter</b>
+ *
+ * <p>Criteria -> Condition 으로 변환
+ *
+ * <p>Data -> ReadModel 으로 변환
+ */
+public class PostQueryConverter {
+
+  /**************************
+   * Request converter
+   * Repository -> Mapper
+   **************************/
+
+  public static PostDetailsCondition postDetailsCondition(PostDetailsCriteria criteria) {
+    return PostDetailsCondition.builder()
+        .visitorType(criteria.type())
+        .vid(criteria.vId())
+        .memberId(criteria.memberId())
+        .postId(criteria.postId())
+        .build();
+  }
+
+  /**************************
+   * Request converter
+   * Repository -> Mapper
+   **************************/
+
+  public static PostDetailsReadModel getPostDetailsReadModel(
+      PostDetailsData info, List<String> hashTags) {
+    return PostDetailsReadModel.builder()
+        .postId(info.postId())
+        .postType(info.postType())
+        .title(info.title())
+        .content(info.content())
+        .likeCount(info.likeCount())
+        .isLiked(info.isLiked())
+        .viewCount(info.viewCount())
+        .hashTags(hashTags)
+        .createdAt(info.createdAt())
+        .updatedAt(info.updatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/mapper/PostDetailsCondition.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/mapper/PostDetailsCondition.java
@@ -1,0 +1,11 @@
+package com.simpleboard.board.board.infrastructure.mybatis.mapper;
+
+import com.simpleboard.board.board.domain.common.vo.VisitorType;
+import lombok.Builder;
+
+/**
+ * <b>Post 상세조회 조건 record</b>
+ */
+@Builder
+public record PostDetailsCondition(
+    Long postId, String vid, Long memberId, VisitorType visitorType) {}

--- a/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/mapper/PostDetailsData.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/mapper/PostDetailsData.java
@@ -1,0 +1,17 @@
+package com.simpleboard.board.board.infrastructure.mybatis.mapper;
+
+import java.time.LocalDateTime;
+
+/**
+ * <b>Post 상세 조회 반환 DTO</b>
+ */
+public record PostDetailsData(
+    Long postId,
+    String postType,
+    String title,
+    String content,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    Long viewCount,
+    Integer likeCount,
+    Boolean isLiked) {}

--- a/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/mapper/PostQueryMapper.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/mapper/PostQueryMapper.java
@@ -1,0 +1,17 @@
+package com.simpleboard.board.board.infrastructure.mybatis.mapper;
+
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * <b>Mybatis용 Mapper 클래스</b>
+ *
+ * <p>Post 조회 요청을 받아 xml 파일에 정의되어 있는 SQL 쿼리 실행</p>
+ */
+@Mapper
+public interface PostQueryMapper {
+  PostDetailsData getPostDetails(PostDetailsCondition condition);
+
+  List<String> getPostHashTags(@Param("postId") Long postId);
+}

--- a/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/repository/PostQueryRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.simpleboard.board.board.infrastructure.mybatis.repository;
+
+import com.simpleboard.board.board.application.query.PostDetailsCriteria;
+import com.simpleboard.board.board.application.query.PostDetailsReadModel;
+import com.simpleboard.board.board.application.query.PostQueryRepository;
+import com.simpleboard.board.board.domain.post.exception.PostNotFoundException;
+import com.simpleboard.board.board.infrastructure.mybatis.converter.PostQueryConverter;
+import com.simpleboard.board.board.infrastructure.mybatis.mapper.PostDetailsData;
+import com.simpleboard.board.board.infrastructure.mybatis.mapper.PostQueryMapper;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PostQueryRepositoryImpl implements PostQueryRepository {
+
+  private final PostQueryMapper postQueryMapper;
+
+  @Override
+  public PostDetailsReadModel getPostDetails(PostDetailsCriteria criteria) {
+    PostDetailsData postDetails =
+        postQueryMapper.getPostDetails(PostQueryConverter.postDetailsCondition(criteria));
+    if (postDetails == null) throw new PostNotFoundException();
+    List<String> postHashTags = postQueryMapper.getPostHashTags(criteria.postId());
+
+    return PostQueryConverter.getPostDetailsReadModel(postDetails, postHashTags);
+  }
+
+  //    @Override
+  //    public PostListQueryResult getPostList(PostListQuery query) {
+  //        PostListCondition condition = QueryConverter.postListCondition(query);
+  //        List<PostListRow> rows = postQueryMapper.getPostList(condition);
+  //
+  //        long totalPosts = postQueryMapper.countPosts(condition);
+  //        long totalComments = postQueryMapper.countCommentsOfBoard(query.boardId());
+  //
+  //
+  //    }
+}

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -12,3 +12,8 @@ app:
       nickname-minutes: 15
       email-minutes: 5
       password-minutes: 5
+
+mybatis:
+  mapper-locations: classpath:/mappers/*.xml
+  configuration:
+    map-underscore-to-camel-case: true

--- a/src/main/resources/mappers/PostQueryMapper.xml
+++ b/src/main/resources/mappers/PostQueryMapper.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.simpleboard.board.board.infrastructure.mybatis.mapper.PostQueryMapper">
+
+    <select id="getPostDetails"
+            parameterType="com.simpleboard.board.board.infrastructure.mybatis.mapper.PostDetailsCondition"
+            resultType="com.simpleboard.board.board.infrastructure.mybatis.mapper.PostDetailsData">
+        SELECT  p.POST_ID        AS postId,
+                p.POST_TYPE      AS postType,
+                p.TITLE          AS title,
+                p.CONTENT        AS content,
+                p.CREATED_AT     AS createdAt,
+                p.UPDATED_AT     AS updatedAt,
+                p.VIEW_COUNT     AS viewCount,
+               COUNT(DISTINCT pl.POSTLIKE_ID) as likeCount,
+               EXISTS(SELECT 1
+                      FROM POST_LIKE pl2
+                      WHERE pl2.POST_ID = #{postId}
+                      <choose>
+                          <when test="visitorType.name() == 'GUEST'">
+                          AND pl2.vid = #{vid}
+                          </when>
+                          <when test="visitorType.name() == 'MEMBER'">
+                              AND pl2.likedMemberId = #{memberId}
+                          </when>
+                          <otherwise>
+                              AND 0
+                          </otherwise>
+                      </choose>
+                      ) as isLiked
+        FROM POST p
+        LEFT JOIN POST_LIKE pl ON p.POST_ID = pl.POST_ID
+        WHERE p.POST_ID = #{postId}
+        GROUP BY p.POST_ID, p.POST_TYPE, p.TITLE, p.CONTENT, p.CREATED_AT, p.UPDATED_AT, p.VIEW_COUNT
+    </select>
+
+    <select id="getPostHashTags"
+            parameterType="Long"
+            resultType="String">
+        SELECT HASHTAG.tag
+        FROM POST_HASHTAG
+        LEFT JOIN HASHTAG ON HASHTAG.HASHTAG_ID = POST_HASHTAG.HASHTAG_ID
+        WHERE POST_HASHTAG.POST_ID = #{postId}
+    </select>
+</mapper>


### PR DESCRIPTION
<!-- 제목은 `[도메인] PR 제목`으로 작성해주세요. (ex) [User] 소셜 로그인 필터 리팩토링 -->
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- Post 상세조회 USECASE에 대한 QueryService, Repository 개발
- MyBatis Mapper, SQL 개발

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->
Query쪽은 DTO 명칭에 대한 고민이 길었습니다.
Domain도 사용하지 않는데다가, repository 조회시 조건을 입력하고 필요한 row만 받아오는 과정에서 추가적인 DTO가 필요하고, Infra 계층 내부에서 Repository <-> Mapper 간의 요청/반환에도 DTO가 필요해 명칭과 체계에 대한 고민을 한참 했습니다.
제가 고안한 Query용 네이밍 컨벤션은 [노션 네이밍컨벤션 페이지](https://www.notion.so/212c71e83f878109aa1ee17fab54a718)에 기재해놨습니다.
계층간 DTO 교환 구조 위주로 봐 주시고 수정사항이나 문제사항, 제안이 있다면 코멘트 작성 부탁드립니다.

또, MyBatis용 SQL 쿼리도 한번 봐주세요.
쿼리를 너무 오랫만에 작성하다 보니 잘 짰나 모르겠네요.

### 📝 메모
<!-- PR 관련 전달사항이 있다면 이곳에 작성해주세요. -->
Query용 Presentation 계층은 아직입니다.
코드가 너무 커지는 듯 하여 짤랐습니다.

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
#100
