### PR TITLE
[Post] USECASE: 목록조회 - application, infra 계층 개발

### DIFF
--- a/src/main/java/com/simpleboard/board/board/application/converter/PostQueryServiceRepoConverter.java
+++ b/src/main/java/com/simpleboard/board/board/application/converter/PostQueryServiceRepoConverter.java
@@ -1,11 +1,16 @@
 package com.simpleboard.board.board.application.converter;
 
 import com.simpleboard.board.board.application.dto.request.PostDetailsQuery;
+import com.simpleboard.board.board.application.dto.request.PostListQuery;
 import com.simpleboard.board.board.application.dto.response.AuthorSummary;
 import com.simpleboard.board.board.application.dto.response.PostDetailsQueryResult;
+import com.simpleboard.board.board.application.dto.response.PostListQueryResult;
 import com.simpleboard.board.board.application.query.PostDetailsCriteria;
 import com.simpleboard.board.board.application.query.PostDetailsReadModel;
+import com.simpleboard.board.board.application.query.PostListCriteria;
+import com.simpleboard.board.board.application.query.PostListReadModel;
 import com.simpleboard.board.board.domain.post.vo.PostTypeEnum;
+import java.util.Map;
 import org.springframework.stereotype.Component;
 
 /** <b>Post query service <-> repository 컨버터</b> */
@@ -23,6 +28,16 @@ public class PostQueryServiceRepoConverter {
         .vId(query.visitor().vId())
         .memberId(query.visitor().memberId())
         .postId(query.postId())
+        .build();
+  }
+
+  public PostListCriteria getCriteria(PostListQuery query) {
+    return PostListCriteria.builder()
+        .boardId(query.boardId())
+        .page(query.page())
+        .size(query.size())
+        .searchType(query.searchType())
+        .keyword(query.keyword())
         .build();
   }
 
@@ -64,6 +79,39 @@ public class PostQueryServiceRepoConverter {
         .hashTags(readModel.hashTags())
         .authorId(authorSummary.authorId())
         .authorNickname(authorSummary.nickname())
+        .build();
+  }
+
+  public PostListQueryResult getQueryResult(
+      Long boardId, String boardName, PostListReadModel readModel, Map<Long, String> nicknameMap) {
+    return PostListQueryResult.builder()
+        .boardId(boardId)
+        .boardName(boardName)
+        .totalPosts(readModel.totalPosts())
+        .totalComments(readModel.totalComments())
+        .page(readModel.page())
+        .size(readModel.size())
+        .posts(
+            readModel.posts().stream()
+                .map(
+                    modelSummary -> {
+                      PostListQueryResult.PostSummary.PostSummaryBuilder builder =
+                          PostListQueryResult.PostSummary.builder()
+                              .postId(modelSummary.postId())
+                              .title(modelSummary.title())
+                              .createdAt(modelSummary.createdAt())
+                              .views(modelSummary.views())
+                              .commentCount(modelSummary.commentCount())
+                              .likeCount(modelSummary.likeCount());
+                      if (modelSummary.postType().equals(PostTypeEnum.MEMBER))
+                        builder.nickname(nicknameMap.get(modelSummary.authorId()));
+                      else if (modelSummary.postType().equals(PostTypeEnum.GUEST))
+                        builder.nickname(modelSummary.nickname());
+                      else throw new IllegalArgumentException();
+
+                      return builder.build();
+                    })
+                .toList())
         .build();
   }
 }

--- a/src/main/java/com/simpleboard/board/board/application/dto/request/PostListQuery.java
+++ b/src/main/java/com/simpleboard/board/board/application/dto/request/PostListQuery.java
@@ -1,0 +1,19 @@
+package com.simpleboard.board.board.application.dto.request;
+
+import lombok.Builder;
+
+/**
+ * <b>Post 목록 조회 요청 모델</b>
+ *
+ * <p>Req: presentation -> application
+ *
+ * @domain request-dto
+ */
+@Builder
+public record PostListQuery(
+    Long boardId,
+    int page,
+    int size,
+    String searchType, // title|nickname|hashtag|content 또는 null
+    String keyword // null 가능
+    ) {}

--- a/src/main/java/com/simpleboard/board/board/application/dto/response/PostListQueryResult.java
+++ b/src/main/java/com/simpleboard/board/board/application/dto/response/PostListQueryResult.java
@@ -1,0 +1,32 @@
+package com.simpleboard.board.board.application.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * <b>Post 목록 조회 응답 모델</b>
+ *
+ * <p>Res: presentation <- application
+ *
+ * @domain response-dto
+ */
+@Builder
+public record PostListQueryResult(
+    Long boardId,
+    String boardName,
+    long totalPosts,
+    long totalComments,
+    int page,
+    int size,
+    List<PostSummary> posts) {
+  @Builder
+  public record PostSummary(
+      Long postId,
+      String title,
+      String nickname,
+      LocalDateTime createdAt,
+      long views,
+      int commentCount,
+      int likeCount) {}
+}

--- a/src/main/java/com/simpleboard/board/board/application/exception/BoardNameNotFound.java
+++ b/src/main/java/com/simpleboard/board/board/application/exception/BoardNameNotFound.java
@@ -1,0 +1,12 @@
+package com.simpleboard.board.board.application.exception;
+
+import com.simpleboard.board.global.exception.ErrorCode;
+import com.simpleboard.board.global.exception.ServiceException;
+
+public class BoardNameNotFound extends ServiceException {
+  private static final ErrorCode ERROR_CODE = ErrorCode.BOARDNAME_NOT_FOUND;
+
+  public BoardNameNotFound() {
+    super(ERROR_CODE);
+  }
+}

--- a/src/main/java/com/simpleboard/board/board/application/query/BoardQueryRepository.java
+++ b/src/main/java/com/simpleboard/board/board/application/query/BoardQueryRepository.java
@@ -1,0 +1,7 @@
+package com.simpleboard.board.board.application.query;
+
+import java.util.Optional;
+
+public interface BoardQueryRepository {
+  Optional<String> findBoardNameById(Long boardId);
+}

--- a/src/main/java/com/simpleboard/board/board/application/query/PostListCriteria.java
+++ b/src/main/java/com/simpleboard/board/board/application/query/PostListCriteria.java
@@ -1,0 +1,20 @@
+package com.simpleboard.board.board.application.query;
+
+import lombok.Builder;
+
+/**
+ * Post 목록 조회 조건 DTO
+ *
+ * <p>Req: service -> repository
+ *
+ * @domain request-dto
+ */
+@Builder
+public record PostListCriteria(
+    Long boardId,
+    String boardName,
+    int page,
+    int size,
+    String searchType, // title|author|hashtag|content 또는 null
+    String keyword // null 가능
+    ) {}

--- a/src/main/java/com/simpleboard/board/board/application/query/PostListReadModel.java
+++ b/src/main/java/com/simpleboard/board/board/application/query/PostListReadModel.java
@@ -1,0 +1,29 @@
+package com.simpleboard.board.board.application.query;
+
+import com.simpleboard.board.board.domain.post.vo.PostTypeEnum;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * Post 목록 조회 반환 DTO
+ *
+ * <p>Res: repository <- service
+ *
+ * @domain response-dto
+ */
+@Builder
+public record PostListReadModel(
+    long totalPosts, long totalComments, int page, int size, List<PostSummary> posts) {
+  @Builder
+  public record PostSummary(
+      Long postId,
+      String title,
+      PostTypeEnum postType,
+      Long authorId,
+      String nickname,
+      LocalDateTime createdAt,
+      long views,
+      int commentCount,
+      int likeCount) {}
+}

--- a/src/main/java/com/simpleboard/board/board/application/query/PostQueryRepository.java
+++ b/src/main/java/com/simpleboard/board/board/application/query/PostQueryRepository.java
@@ -10,4 +10,6 @@ package com.simpleboard.board.board.application.query;
 public interface PostQueryRepository {
 
   PostDetailsReadModel getPostDetails(PostDetailsCriteria criteria);
+
+  PostListReadModel getPostList(PostListCriteria criteria);
 }

--- a/src/main/java/com/simpleboard/board/board/application/service/MemberFetchService.java
+++ b/src/main/java/com/simpleboard/board/board/application/service/MemberFetchService.java
@@ -1,6 +1,7 @@
 package com.simpleboard.board.board.application.service;
 
 import com.simpleboard.board.board.application.dto.response.AuthorSummary;
+import java.util.List;
 
 /**
  * <b>Member Data 조회 서비스 클래스</b>
@@ -8,5 +9,17 @@ import com.simpleboard.board.board.application.dto.response.AuthorSummary;
  * <p>Member B.C의 internal API를 통해 데이터를 Fetch
  */
 public interface MemberFetchService {
+  /**
+   * <b>Author summary 단일 조회 메서드</b>
+   *
+   * @since 1.0
+   */
   AuthorSummary getAuthorSummary(Long authorId);
+
+  /**
+   * <b>Author summary 다중 조회 메서드</b>
+   *
+   * @since 1.0
+   */
+  List<AuthorSummary> fetchAuthorSummaryList(List<Long> authorIds);
 }

--- a/src/main/java/com/simpleboard/board/board/application/service/PostQueryService.java
+++ b/src/main/java/com/simpleboard/board/board/application/service/PostQueryService.java
@@ -1,7 +1,9 @@
 package com.simpleboard.board.board.application.service;
 
 import com.simpleboard.board.board.application.dto.request.PostDetailsQuery;
+import com.simpleboard.board.board.application.dto.request.PostListQuery;
 import com.simpleboard.board.board.application.dto.response.PostDetailsQueryResult;
+import com.simpleboard.board.board.application.dto.response.PostListQueryResult;
 
 /**
  * <b>Post 조회 유스케이스</b>
@@ -13,4 +15,6 @@ import com.simpleboard.board.board.application.dto.response.PostDetailsQueryResu
  */
 public interface PostQueryService {
   PostDetailsQueryResult getPostDetails(PostDetailsQuery query);
+
+  PostListQueryResult getPostList(PostListQuery query);
 }

--- a/src/main/java/com/simpleboard/board/board/application/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/simpleboard/board/board/application/service/PostQueryServiceImpl.java
@@ -2,12 +2,20 @@ package com.simpleboard.board.board.application.service;
 
 import com.simpleboard.board.board.application.converter.PostQueryServiceRepoConverter;
 import com.simpleboard.board.board.application.dto.request.PostDetailsQuery;
+import com.simpleboard.board.board.application.dto.request.PostListQuery;
 import com.simpleboard.board.board.application.dto.response.AuthorSummary;
 import com.simpleboard.board.board.application.dto.response.PostDetailsQueryResult;
+import com.simpleboard.board.board.application.dto.response.PostListQueryResult;
+import com.simpleboard.board.board.application.exception.BoardNameNotFound;
+import com.simpleboard.board.board.application.query.BoardQueryRepository;
 import com.simpleboard.board.board.application.query.PostDetailsReadModel;
+import com.simpleboard.board.board.application.query.PostListReadModel;
 import com.simpleboard.board.board.application.query.PostQueryRepository;
 import com.simpleboard.board.board.domain.post.exception.PostNotFoundException;
 import com.simpleboard.board.board.domain.post.vo.PostTypeEnum;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +24,7 @@ import org.springframework.stereotype.Service;
 public class PostQueryServiceImpl implements PostQueryService {
 
   private final PostQueryRepository postQueryRepository;
+  private final BoardQueryRepository boardQueryRepository;
   private final MemberFetchService memberFetchService;
   private final PostQueryServiceRepoConverter converter;
 
@@ -29,5 +38,27 @@ public class PostQueryServiceImpl implements PostQueryService {
       return converter.getQueryResult(readModel, summary);
     }
     return converter.getQueryResult(readModel);
+  }
+
+  @Override
+  public PostListQueryResult getPostList(PostListQuery query) {
+    // board name 조회
+    String boardName =
+        boardQueryRepository.findBoardNameById(query.boardId()).orElseThrow(BoardNameNotFound::new);
+
+    // post 목록 조회
+    PostListReadModel readModel = postQueryRepository.getPostList(converter.getCriteria(query));
+
+    // 목록 내 member post의 nickname 조회
+    List<Long> authorIds =
+        readModel.posts().stream()
+            .filter(p -> p.postType().equals(PostTypeEnum.MEMBER))
+            .map(p -> p.authorId())
+            .toList();
+    Map<Long, String> nicknameMap =
+        memberFetchService.fetchAuthorSummaryList(authorIds).stream()
+            .collect(Collectors.toMap(AuthorSummary::authorId, summary -> summary.nickname()));
+
+    return converter.getQueryResult(query.boardId(), boardName, readModel, nicknameMap);
   }
 }

--- a/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/converter/PostQueryConverter.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/converter/PostQueryConverter.java
@@ -2,8 +2,12 @@ package com.simpleboard.board.board.infrastructure.mybatis.converter;
 
 import com.simpleboard.board.board.application.query.PostDetailsCriteria;
 import com.simpleboard.board.board.application.query.PostDetailsReadModel;
+import com.simpleboard.board.board.application.query.PostListCriteria;
+import com.simpleboard.board.board.application.query.PostListReadModel;
 import com.simpleboard.board.board.infrastructure.mybatis.mapper.PostDetailsCondition;
 import com.simpleboard.board.board.infrastructure.mybatis.mapper.PostDetailsData;
+import com.simpleboard.board.board.infrastructure.mybatis.mapper.PostListCondition;
+import com.simpleboard.board.board.infrastructure.mybatis.mapper.PostSummaryData;
 import java.util.List;
 
 /**
@@ -29,6 +33,16 @@ public class PostQueryConverter {
         .build();
   }
 
+  public static PostListCondition postListCondition(PostListCriteria criteria) {
+    return PostListCondition.builder()
+        .boardId(criteria.boardId())
+        .limit(criteria.size())
+        .offset(criteria.page() * criteria.size())
+        .searchType(criteria.searchType())
+        .keyword(criteria.keyword())
+        .build();
+  }
+
   /**************************
    * Request converter
    * Repository -> Mapper
@@ -47,6 +61,35 @@ public class PostQueryConverter {
         .hashTags(hashTags)
         .createdAt(info.createdAt())
         .updatedAt(info.updatedAt())
+        .build();
+  }
+
+  public static PostListReadModel getPostListReadModel(
+      PostListCriteria criteria, List<PostSummaryData> rows, long totalPosts, long totalComments) {
+    long startIdx = criteria.page() * criteria.size();
+    long endIdx = startIdx + rows.size();
+    long newPage = (endIdx + 1) / criteria.size();
+    return PostListReadModel.builder()
+        .totalPosts(totalPosts)
+        .totalComments(totalComments)
+        .page((int) newPage)
+        .size(criteria.size())
+        .posts(
+            rows.stream()
+                .map(
+                    (row) ->
+                        PostListReadModel.PostSummary.builder()
+                            .postId(row.postId())
+                            .title(row.title())
+                            .postType(row.postType())
+                            .authorId(row.authorId())
+                            .nickname(row.nickname())
+                            .createdAt(row.createdAt())
+                            .views(row.views())
+                            .commentCount(row.commentCount())
+                            .likeCount(row.likeCount())
+                            .build())
+                .toList())
         .build();
   }
 }

--- a/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/mapper/PostListCondition.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/mapper/PostListCondition.java
@@ -1,0 +1,19 @@
+package com.simpleboard.board.board.infrastructure.mybatis.mapper;
+
+import lombok.Builder;
+
+/**
+ * <b>Post 목록 조회 Condition</b>
+ *
+ * <p>Req: repository -> mapper
+ *
+ * @domain request-dto
+ */
+@Builder
+public record PostListCondition(
+    Long boardId,
+    int limit,
+    int offset,
+    String searchType, // TITLE|NICKNAME|HASHTAG|CONTENT 또는 null
+    String keyword // null 가능
+    ) {}

--- a/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/mapper/PostQueryMapper.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/mapper/PostQueryMapper.java
@@ -7,11 +7,17 @@ import org.springframework.data.repository.query.Param;
 /**
  * <b>Mybatis용 Mapper 클래스</b>
  *
- * <p>Post 조회 요청을 받아 xml 파일에 정의되어 있는 SQL 쿼리 실행</p>
+ * <p>Post 조회 요청을 받아 xml 파일에 정의되어 있는 SQL 쿼리 실행
  */
 @Mapper
 public interface PostQueryMapper {
   PostDetailsData getPostDetails(PostDetailsCondition condition);
 
   List<String> getPostHashTags(@Param("postId") Long postId);
+
+  List<PostSummaryData> getPostList(PostListCondition condition);
+
+  long countPosts(PostListCondition condition);
+
+  long countCommentsOfBoard(@Param("boardId") Long boardId);
 }

--- a/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/mapper/PostSummaryData.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/mapper/PostSummaryData.java
@@ -1,0 +1,25 @@
+package com.simpleboard.board.board.infrastructure.mybatis.mapper;
+
+import com.simpleboard.board.board.domain.post.vo.PostTypeEnum;
+
+import java.time.LocalDateTime;
+
+/**
+ * <b>Post 목록 조회 응답 모델</b>
+ *
+ * <p>Post 한개에 대한 메타 정보를 담은 DTO
+ *
+ * <p>Res: repository <- mapper
+ *
+ * @domain response-dto
+ */
+public record PostSummaryData(
+    Long postId,
+    PostTypeEnum postType,
+    String title,
+    Long authorId,
+    String nickname, // member post에서 null
+    Long views,
+    Integer commentCount,
+    Integer likeCount,
+    LocalDateTime createdAt) {}

--- a/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/repository/PostQueryRepositoryImpl.java
@@ -1,12 +1,12 @@
 package com.simpleboard.board.board.infrastructure.mybatis.repository;
 
-import com.simpleboard.board.board.application.query.PostDetailsCriteria;
-import com.simpleboard.board.board.application.query.PostDetailsReadModel;
-import com.simpleboard.board.board.application.query.PostQueryRepository;
+import com.simpleboard.board.board.application.query.*;
 import com.simpleboard.board.board.domain.post.exception.PostNotFoundException;
 import com.simpleboard.board.board.infrastructure.mybatis.converter.PostQueryConverter;
 import com.simpleboard.board.board.infrastructure.mybatis.mapper.PostDetailsData;
+import com.simpleboard.board.board.infrastructure.mybatis.mapper.PostListCondition;
 import com.simpleboard.board.board.infrastructure.mybatis.mapper.PostQueryMapper;
+import com.simpleboard.board.board.infrastructure.mybatis.mapper.PostSummaryData;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -27,14 +27,14 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
     return PostQueryConverter.getPostDetailsReadModel(postDetails, postHashTags);
   }
 
-  //    @Override
-  //    public PostListQueryResult getPostList(PostListQuery query) {
-  //        PostListCondition condition = QueryConverter.postListCondition(query);
-  //        List<PostListRow> rows = postQueryMapper.getPostList(condition);
-  //
-  //        long totalPosts = postQueryMapper.countPosts(condition);
-  //        long totalComments = postQueryMapper.countCommentsOfBoard(query.boardId());
-  //
-  //
-  //    }
+  @Override
+  public PostListReadModel getPostList(PostListCriteria criteria) {
+    PostListCondition condition = PostQueryConverter.postListCondition(criteria);
+    List<PostSummaryData> rows = postQueryMapper.getPostList(condition);
+
+    long totalPosts = postQueryMapper.countPosts(condition);
+    long totalComments = postQueryMapper.countCommentsOfBoard(criteria.boardId());
+
+    return PostQueryConverter.getPostListReadModel(criteria, rows, totalPosts, totalComments);
+  }
 }

--- a/src/main/java/com/simpleboard/board/global/exception/ErrorCode.java
+++ b/src/main/java/com/simpleboard/board/global/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
   POST_HASHTAG_SIZE_EXCEED(
       HttpStatus.BAD_REQUEST, "400_HASHTAG_SIZE_TOO_LARGE", "Hashtag의 개수가 너무 많습니다."),
   POST_NOT_FOUNT(HttpStatus.NOT_FOUND, "404_POST_NOT_FOUND", "Post를 찾을 수 없습니다."),
+  BOARDNAME_NOT_FOUND(HttpStatus.NOT_FOUND, "404_BOARDNAME_NOT_FOUND", "존재하지 않는 board name입니다."),
 
   // Comment
   COMMENT_MEMBER_NO_PERMISSION(

--- a/src/main/resources/mappers/PostQueryMapper.xml
+++ b/src/main/resources/mappers/PostQueryMapper.xml
@@ -43,4 +43,75 @@
         LEFT JOIN HASHTAG ON HASHTAG.HASHTAG_ID = POST_HASHTAG.HASHTAG_ID
         WHERE POST_HASHTAG.POST_ID = #{postId}
     </select>
+
+    <select id="getPostList"
+            parameterType="com.simpleboard.board.board.infrastructure.mybatis.mapper.PostListCondition"
+            resultType="com.simpleboard.board.board.infrastructure.mybatis.mapper.PostSummaryData">
+
+        SELECT p.POST_ID        AS postId,
+               p.POST_TYPE      AS postType,
+               p.TITLE          AS title,
+               p.MEMBER_ID      AS authorId,
+               p.NICKNAME       AS nickname,
+               p.VIEW_COUNT     AS views,
+               COALESCE(cc.cnt, 0)  AS commentCount,
+               COALESCE(lc.cnt, 0)  AS likeCount,
+               p.CREATED_AT     AS createdAt
+        FROM POST p
+
+        <!-- comment count 사전 집계 -->
+        LEFT JOIN (SELECT POST_ID, COUNT(*) AS cnt
+                   FROM COMMENT
+                   WHERE COMMENT_STATE = 'ACTIVE'
+                   GROUP BY POST_ID) cc
+            ON cc.POST_ID = p.POST_ID
+
+        <!-- like count 사전 집계 -->
+        LEFT JOIN (SELECT POST_ID, COUNT(*) AS cnt
+                   FROM POST_LIKE
+                   GROUP BY POST_ID) lc
+            ON lc.POST_ID = p.POST_ID
+
+        <!-- HashTag 검색 -->
+        <if test="searchType == 'HASHTAG'">
+            INNER JOIN POST_HASHTAG ph ON ph.POST_ID = p.POST_ID
+            INNER JOIN HASHTAG h ON h.HASHTAG_ID = ph.HASHTAG_ID AND h.TAG = #{keyword}
+        </if>
+
+        WHERE p.IS_DELETED = false
+        <choose>
+            <when test="searchType == 'TITLE'">
+                AND p.TITLE LIKE CONCAT('%', #{keyword}, '%')
+            </when>
+            <when test="searchType == 'NICKNAME'">
+                AND p.NICKNAME LIKE CONCAT('%', #{keyword}, '%')
+            </when>
+            <when test="searchType == 'CONTENT'">
+                AND p.CONTENT LIKE CONCAT('%', #{keyword}, '%')
+            </when>
+        </choose>
+
+        ORDER BY p.CREATED_AT DESC
+        LIMIT #{limit}
+        OFFSET #{offset}
+
+    </select>
+
+    <select id="countPosts"
+            parameterType="com.simpleboard.board.board.infrastructure.mybatis.mapper.PostListCondition"
+            resultType="Long">
+        SELECT COUNT(*)
+        FROM POST p
+        WHERE p.BOARD_ID = #{boardId} AND p.IS_DELETED = false
+    </select>
+
+    <select id="countCommentsOfBoard"
+            parameterType="Long"
+            resultType="Long">
+        SELECT COUNT(*)
+        FROM POST p
+                 JOIN COMMENT c ON c.POST_ID = p.POST_ID
+        WHERE p.BOARD_ID = #{boardId}
+          AND c.COMMENT_STATE = 'ACTIVE';
+    </select>
 </mapper>


### PR DESCRIPTION
<!-- 제목은 `[도메인] PR 제목`으로 작성해주세요. (ex) [User] 소셜 로그인 필터 리팩토링 -->
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- 목록조회 USECASE에 대한 application, infra 계층 개발
- USECASE에 대한 QueryService 개발
- USECASE에 대한 Repository 개발
- MyBatis SQL 추가

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->
쿼리 서비스를 보시면 Post의 목록을 DB에서 조회한 뒤, MemberPost들에 대해 authorId를 List에 모아 MemberFetchService에 전달합니다. (MemberFetchService의 구현체는 아직 개발하지 못했습니다)

그런데 저게 최선의 구조인지는 모르겠습니다.
Post 목록 조회는 Post 단건 조회와 함께 가장 많이 사용되는 USECASE일 텐데, 매 조회마다 닉네임을 조회하기 위해 internal API를 쓰는 저런 형태가 최선일까요?

반환값을 Map에 담은 뒤 뽑아쓰는것도 찜찜하네요. (서비스-레포 컨버터에 관련 로직 있습니다)
컨버터도 너무 복잡해졌고요...

혹시 아이디어 있다면 편하게 제안해주세요.

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
#100 
