### PR TITLE
[Auth] Auth B.C Controller 개발

### DIFF
--- a/src/main/java/com/simpleboard/board/auth/application/service/TokenApplicationServiceImpl.java
+++ b/src/main/java/com/simpleboard/board/auth/application/service/TokenApplicationServiceImpl.java
@@ -1,0 +1,42 @@
+package com.simpleboard.board.auth.application.service;
+
+import com.simpleboard.board.auth.domain.token.dto.request.RefreshTokenRotationParam;
+import com.simpleboard.board.auth.domain.token.dto.request.VerifyTokenIssueParam;
+import com.simpleboard.board.auth.domain.token.service.TokenDomainService;
+import com.simpleboard.board.auth.domain.token.vo.Token;
+import com.simpleboard.board.auth.domain.token.vo.TokenPair;
+import com.simpleboard.board.auth.domain.token.vo.VerifyPurpose;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenApplicationServiceImpl implements TokenApplicationService {
+
+    private final TokenDomainService tokenDomainService;
+
+    @Override
+    public TokenPair rotateRefreshToken(String refreshTokenRaw) {
+        return tokenDomainService.rotateRefreshToken(
+                RefreshTokenRotationParam.builder()
+                        .oldRefreshRaw(refreshTokenRaw).build());
+    }
+
+    @Override
+    public Token issueVerifyToken(String subject, VerifyPurpose purpose) {
+        return tokenDomainService.issueVerifyToken(
+                VerifyTokenIssueParam.builder()
+                        .subject(subject)
+                        .purpose(purpose).build());
+    }
+
+    @Override
+    public void enrollBlacklist(String tokenRaw) {
+        tokenDomainService.enrollBlacklist(tokenRaw);
+    }
+
+    @Override
+    public void blockSnatchedToken(String tokenRaw) {
+        tokenDomainService.blockTokenUser(tokenRaw);
+    }
+}

--- a/src/main/java/com/simpleboard/board/auth/application/service/UserAuthCommandServiceImpl.java
+++ b/src/main/java/com/simpleboard/board/auth/application/service/UserAuthCommandServiceImpl.java
@@ -1,0 +1,55 @@
+package com.simpleboard.board.auth.application.service;
+
+import com.simpleboard.board.auth.application.dto.request.EmailMemberRegisterCommand;
+import com.simpleboard.board.auth.application.dto.request.OAuthMemberRegisterCommand;
+import com.simpleboard.board.auth.application.exception.UserNotFoundException;
+import com.simpleboard.board.auth.domain.auth.dto.request.RegisterParams;
+import com.simpleboard.board.auth.domain.auth.entity.UserAuth;
+import com.simpleboard.board.auth.domain.auth.repository.UserAuthCommandRepository;
+import com.simpleboard.board.auth.domain.auth.vo.RegisterType;
+import com.simpleboard.board.auth.domain.common.vo.Role;
+import com.simpleboard.board.auth.domain.token.service.TokenDomainService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserAuthCommandServiceImpl implements UserAuthCommandService {
+
+  private final TokenDomainService tokenDomainService;
+  private final UserAuthCommandRepository authCommandRepository;
+
+  @Override
+  public void emailMemberRegister(EmailMemberRegisterCommand command) {
+    String email =
+        tokenDomainService.validateAndParseVerifyToken(command.emailTokenRaw()).subject();
+    String nickname =
+        tokenDomainService.validateAndParseVerifyToken(command.nicknameTokenRaw()).subject();
+
+    UserAuth register =
+        UserAuth.register(
+            RegisterParams.builder()
+                .registerType(RegisterType.EMAIL)
+                .role(Role.MEMBER)
+                .email(email)
+                .password(command.password())
+                .build());
+
+    UserAuth saved = authCommandRepository.save(register);
+    // TODO: EmailUserRegistered Event
+  }
+
+  @Override
+  public void oAuthMemberRegister(OAuthMemberRegisterCommand command) {
+    // TODO: implements OAuth user register
+  }
+
+  @Override
+  public void deactivateAccount(Long memberId) {
+    UserAuth userAuth =
+        authCommandRepository.findById(memberId).orElseThrow(UserNotFoundException::new);
+    userAuth.delete();
+    authCommandRepository.save(userAuth);
+    // TODO: UserDeleted Event
+  }
+}

--- a/src/main/java/com/simpleboard/board/auth/domain/auth/entity/UserAuth.java
+++ b/src/main/java/com/simpleboard/board/auth/domain/auth/entity/UserAuth.java
@@ -1,5 +1,6 @@
 package com.simpleboard.board.auth.domain.auth.entity;
 
+import com.simpleboard.board.auth.application.exception.UserDisabledException;
 import com.simpleboard.board.auth.domain.auth.dto.request.RegisterParams;
 import com.simpleboard.board.auth.domain.auth.vo.RegisterType;
 import com.simpleboard.board.auth.domain.auth.vo.UserState;
@@ -29,6 +30,19 @@ public abstract class UserAuth {
     userState = UserState.ACTIVE;
     registerType = params.registerType();
     role = params.role();
+  }
+
+  /**
+   * <b>회원 탈퇴 메서드</b>
+   *
+   * <p>ACTIVE 상태의 유저를 DELETED 상태로 변환(soft deletion)
+   *
+   * @throws UserDisabledException - 유저가 ACTIVE 상태가 아님
+   * @since 1.0
+   */
+  public void delete() {
+    if (userState != UserState.ACTIVE) throw new UserDisabledException();
+    userState = UserState.DELETED;
   }
 
   /**

--- a/src/main/java/com/simpleboard/board/auth/domain/token/dto/request/VerifyTokenIssueParam.java
+++ b/src/main/java/com/simpleboard/board/auth/domain/token/dto/request/VerifyTokenIssueParam.java
@@ -1,6 +1,8 @@
 package com.simpleboard.board.auth.domain.token.dto.request;
 
 import com.simpleboard.board.auth.domain.token.vo.VerifyPurpose;
+import lombok.Builder;
+
 import java.time.Duration;
 
 /**
@@ -11,4 +13,5 @@ import java.time.Duration;
  * @domain request-dto
  * @since 1.0
  */
-public record VerifyTokenIssueParam(VerifyPurpose purpose, String subject, Duration ttl) {}
+@Builder
+public record VerifyTokenIssueParam(VerifyPurpose purpose, String subject) {}

--- a/src/main/java/com/simpleboard/board/auth/domain/token/service/TokenDomainService.java
+++ b/src/main/java/com/simpleboard/board/auth/domain/token/service/TokenDomainService.java
@@ -184,10 +184,20 @@ public class TokenDomainService {
     TokenClaims claims =
         tokenProvider.verifyAndParseToken(refreshTokenRaw, Date.from(clockManager.now()));
 
-    if (!claims.tokenPurpose().equals(TokenPurpose.REFRESH))
-      throw new RefreshTokenEnrollBlacklistException();
-    if (claims.isExpired(clockManager.now())) throw new RefreshTokenInvalidException();
-    blacklistRepository.save(claims.tokenId(), claims.expiredAt());
+    blacklist(claims);
+  }
+
+  public void blockTokenUser(String refreshTokenRaw){
+    TokenClaims claims =
+            tokenProvider.verifyAndParseToken(refreshTokenRaw, Date.from(clockManager.now()));
+
+    // enroll token on blacklist
+    blacklist(claims);
+
+    // update member's uuid
+    String uuid = claims.subject();
+    Long memberId = uuidRepository.getMemberId(uuid).orElseThrow(TokenUserBlockedException::new);
+    uuidRepository.updateUUID(memberId);
   }
 
   private TokenClaims createAccessClaims(String memberUUID, Role role, Instant now) {
@@ -234,6 +244,13 @@ public class TokenDomainService {
         tokenProvider.issueToken(createRefreshClaims(memberUUID, role, refreshTokenIssueTime));
 
     return TokenPair.builder().access(accessToken).refresh(newRefreshToken).build();
+  }
+
+  private void blacklist(TokenClaims claims) {
+    if (!claims.tokenPurpose().equals(TokenPurpose.REFRESH))
+      throw new RefreshTokenEnrollBlacklistException();
+    if (claims.isExpired(clockManager.now())) throw new RefreshTokenInvalidException();
+    blacklistRepository.save(claims.tokenId(), claims.expiredAt());
   }
 
   private static LoginTokenInfo createLoginTokenInfo(TokenClaims tokenClaims, Long memberId) {

--- a/src/main/java/com/simpleboard/board/auth/presentation/dto/request/EmailRegisterForm.java
+++ b/src/main/java/com/simpleboard/board/auth/presentation/dto/request/EmailRegisterForm.java
@@ -1,0 +1,10 @@
+package com.simpleboard.board.auth.presentation.dto.request;
+
+/**
+ * Email 회원 가입 요청 모델.
+ *
+ * <p>Req: Client -> Presentation
+ *
+ * @domain request-dto
+ */
+public record EmailRegisterForm(String password, String gender, int birthYear) {}

--- a/src/main/java/com/simpleboard/board/auth/presentation/exception/EmailRegisterTokenException.java
+++ b/src/main/java/com/simpleboard/board/auth/presentation/exception/EmailRegisterTokenException.java
@@ -1,0 +1,12 @@
+package com.simpleboard.board.auth.presentation.exception;
+
+import com.simpleboard.board.global.exception.ErrorCode;
+import com.simpleboard.board.global.exception.ServiceException;
+
+public class EmailRegisterTokenException extends ServiceException {
+  private static final ErrorCode ERROR_CODE = ErrorCode.MISSING_REGISTER_TOKEN;
+
+  public EmailRegisterTokenException() {
+    super(ERROR_CODE);
+  }
+}

--- a/src/main/java/com/simpleboard/board/auth/presentation/util/AuthStringProvider.java
+++ b/src/main/java/com/simpleboard/board/auth/presentation/util/AuthStringProvider.java
@@ -11,6 +11,8 @@ public class AuthStringProvider {
 
   public static class Cookie {
     public static final String REFRESH_COOKIE = "Authorization-Refresh";
+    public static final String REGISTER_EMAIL_COOKIE = "Register-Email";
+    public static final String REGISTER_NICKNAME_COOKIE = "Register-Nickname";
   }
 
   public static class Token{

--- a/src/main/java/com/simpleboard/board/auth/presentation/web/AuthenticationController.java
+++ b/src/main/java/com/simpleboard/board/auth/presentation/web/AuthenticationController.java
@@ -1,0 +1,73 @@
+package com.simpleboard.board.auth.presentation.web;
+
+import static com.simpleboard.board.auth.presentation.util.AuthStringProvider.Cookie.REFRESH_COOKIE;
+import static com.simpleboard.board.auth.presentation.util.AuthStringProvider.Header.AUTHORIZATION;
+import static com.simpleboard.board.auth.presentation.util.AuthStringProvider.Header.BEARER;
+
+import com.simpleboard.board.auth.application.service.TokenApplicationService;
+import com.simpleboard.board.auth.application.service.UserAuthCommandService;
+import com.simpleboard.board.auth.domain.token.exception.RefreshTokenInvalidException;
+import com.simpleboard.board.auth.domain.token.vo.TokenPair;
+import com.simpleboard.board.auth.presentation.util.CookieUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/auth")
+@Tag(name = "인증", description = "토큰, 인증 관련 API")
+public class AuthenticationController {
+
+  private final CookieUtils cookieUtils;
+  private final TokenApplicationService tokenApplicationService;
+  private final UserAuthCommandService userAuthCommandService;
+
+  @Operation(
+      summary = "Access 토큰 재발급",
+      description = "refresh token을 사용하여 access 토큰을 재발급, refresh 토큰은 rotation")
+  @PostMapping("/token/rotate")
+  public ResponseEntity<Void> reclaimAccessToken(
+      HttpServletRequest request, HttpServletResponse response) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies == null) throw new RefreshTokenInvalidException();
+    String refreshTokenRaw = getCookieToken(cookies, REFRESH_COOKIE);
+    TokenPair pair = tokenApplicationService.rotateRefreshToken(refreshTokenRaw);
+    response.addHeader(AUTHORIZATION, BEARER + pair.access().raw());
+    response.setHeader("Cache-Control", "no-store");
+    response.setHeader("Pragma", "no-cache");
+    response.addCookie(cookieUtils.buildCookie(pair.refresh(), REFRESH_COOKIE));
+    return ResponseEntity.ok().build();
+  }
+
+  @Operation(summary = "로그아웃", description = "refresh token 쿠키를 만료시키고 토큰을 블랙리스트에 등록")
+  @PostMapping("/signout")
+  public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies != null) {
+      Arrays.stream(cookies)
+          .filter(cookie -> cookie.getName().equals(REFRESH_COOKIE))
+          .findFirst()
+          .ifPresent(
+              refreeshCookie -> tokenApplicationService.enrollBlacklist(refreeshCookie.getValue()));
+    }
+    response.addCookie(cookieUtils.expire(REFRESH_COOKIE));
+    return ResponseEntity.noContent().build();
+  }
+
+  private String getCookieToken(Cookie[] cookies, String cookieName) {
+    String refreshTokenRaw =
+        Arrays.stream(cookies)
+            .filter(cookie -> cookie.getName().equals(cookieName))
+            .findFirst()
+            .orElseThrow(RefreshTokenInvalidException::new)
+            .getValue();
+    return refreshTokenRaw;
+  }
+}

--- a/src/main/java/com/simpleboard/board/auth/presentation/web/UserAuthController.java
+++ b/src/main/java/com/simpleboard/board/auth/presentation/web/UserAuthController.java
@@ -1,0 +1,72 @@
+package com.simpleboard.board.auth.presentation.web;
+
+import static com.simpleboard.board.auth.presentation.util.AuthStringProvider.Cookie.REGISTER_EMAIL_COOKIE;
+
+import com.simpleboard.board.auth.application.dto.request.EmailMemberRegisterCommand;
+import com.simpleboard.board.auth.application.service.AuthPrincipal;
+import com.simpleboard.board.auth.application.service.UserAuthCommandService;
+import com.simpleboard.board.auth.domain.token.exception.RefreshTokenInvalidException;
+import com.simpleboard.board.auth.presentation.dto.request.EmailRegisterForm;
+import com.simpleboard.board.auth.presentation.exception.EmailRegisterTokenException;
+import com.simpleboard.board.auth.presentation.util.AuthStringProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/auth")
+@Tag(name = "회원 인증 정보", description = "회원의 가입, 탈퇴 관련 API")
+public class UserAuthController {
+
+  private final UserAuthCommandService userAuthCommandService;
+
+  @Operation(summary = "Email 회원가입", description = "email 토큰과 nickname 토큰을 통해 Email 유저 회원가입을 진행")
+  @PostMapping("/register/email")
+  public ResponseEntity<Void> registerEmailUser(
+      HttpServletRequest request, @RequestBody @Valid EmailRegisterForm form) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies == null) throw new EmailRegisterTokenException();
+    String emailToken = getCookieToken(cookies, REGISTER_EMAIL_COOKIE);
+    String nicknameToken =
+        getCookieToken(cookies, AuthStringProvider.Cookie.REGISTER_NICKNAME_COOKIE);
+
+    EmailMemberRegisterCommand command =
+        EmailMemberRegisterCommand.builder()
+            .birthYear(form.birthYear())
+            .password(form.password())
+            .gender(form.gender())
+            .emailTokenRaw(emailToken)
+            .nicknameTokenRaw(nicknameToken)
+            .build();
+
+    userAuthCommandService.emailMemberRegister(command);
+    return ResponseEntity.created(URI.create("/login")).build();
+  }
+
+  @Operation(summary = "회원 탈퇴", description = "로그인된 유저의 회원 탈퇴를 진행합니다.")
+  @DeleteMapping("/user")
+  public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal AuthPrincipal authPrincipal) {
+    Long userId = authPrincipal.getUserId();
+    userAuthCommandService.deactivateAccount(userId);
+    return ResponseEntity.noContent().build();
+  }
+
+  private String getCookieToken(Cookie[] cookies, String cookieName) {
+    String refreshTokenRaw =
+        Arrays.stream(cookies)
+            .filter(cookie -> cookie.getName().equals(cookieName))
+            .findFirst()
+            .orElseThrow(RefreshTokenInvalidException::new)
+            .getValue();
+    return refreshTokenRaw;
+  }
+}

--- a/src/main/java/com/simpleboard/board/global/exception/ErrorCode.java
+++ b/src/main/java/com/simpleboard/board/global/exception/ErrorCode.java
@@ -58,6 +58,8 @@ public enum ErrorCode {
   NICKNAME_CONFLICT(HttpStatus.CONFLICT, "409_NICKNAME_CONFLICT", "이미 사용중인 nickname입니다."),
   EMAIL_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "400_EMAIL_CODE_MISMATCH", "email 코드가 일치하지 않습니다."),
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "404_USER_NOT_FOUND", "일치하는 유저가 존재하지 않습니다."),
+  MISSING_REGISTER_TOKEN(
+      HttpStatus.BAD_REQUEST, "400_MISSING_REGISTER_TOKEN", "회원가입에 필요한 토큰이 누락되었습니다."),
 
   /* Internal Error */
   INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500_INTERNAL", "서버 내부 오류가 발생했습니다."),

--- a/src/test/java/com/simpleboard/board/auth/application/service/TokenApplicationServiceTest.java
+++ b/src/test/java/com/simpleboard/board/auth/application/service/TokenApplicationServiceTest.java
@@ -1,0 +1,115 @@
+package com.simpleboard.board.auth.application.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.simpleboard.board.auth.domain.token.dto.request.RefreshTokenRotationParam;
+import com.simpleboard.board.auth.domain.token.dto.request.VerifyTokenIssueParam;
+import com.simpleboard.board.auth.domain.token.exception.RefreshTokenInvalidException;
+import com.simpleboard.board.auth.domain.token.service.TokenDomainService;
+import com.simpleboard.board.auth.domain.token.vo.Token;
+import com.simpleboard.board.auth.domain.token.vo.TokenPair;
+import com.simpleboard.board.auth.domain.token.vo.VerifyPurpose;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class TokenApplicationServiceTest {
+
+    private TokenDomainService tokenDomainService;
+    private TokenApplicationService service;
+
+    @BeforeEach
+    void setUp() {
+        tokenDomainService = mock(TokenDomainService.class);
+        service = new TokenApplicationServiceImpl(tokenDomainService);
+    }
+
+    @Test
+    @DisplayName("리프레시 로테이션 성공: 파라미터 위임 및 반환값 전달")
+    void rotateRefreshToken_Success_Test() {
+        // given
+        String oldRaw = "old-refresh";
+        TokenPair pair =
+                TokenPair.builder()
+                        .access(Token.builder().raw("a").expiredAt(Instant.now().plusSeconds(10)).build())
+                        .refresh(Token.builder().raw("r").expiredAt(Instant.now().plusSeconds(100)).build())
+                        .build();
+        when(tokenDomainService.rotateRefreshToken(any(RefreshTokenRotationParam.class)))
+                .thenReturn(pair);
+
+        // when
+        TokenPair result = service.rotateRefreshToken(oldRaw);
+
+        // then
+        assertThat(result).isEqualTo(pair);
+
+        ArgumentCaptor<RefreshTokenRotationParam> captor =
+                ArgumentCaptor.forClass(RefreshTokenRotationParam.class);
+        verify(tokenDomainService).rotateRefreshToken(captor.capture());
+        assertThat(captor.getValue().oldRefreshRaw()).isEqualTo(oldRaw);
+    }
+
+    @Test
+    @DisplayName("리프레시 로테이션 실패: 도메인 예외 전파")
+    void rotateRefreshToken_Propagate_Exception_Test() {
+        // given
+        when(tokenDomainService.rotateRefreshToken(any(RefreshTokenRotationParam.class)))
+                .thenThrow(new RefreshTokenInvalidException());
+
+        // when & then
+        assertThatThrownBy(() -> service.rotateRefreshToken("bad"))
+                .isInstanceOf(RefreshTokenInvalidException.class);
+    }
+
+    @Test
+    @DisplayName("Verify 토큰 발급 성공: 파라미터 위임 및 반환값 전달")
+    void issueVerifyToken_Success_Test() {
+        // given
+        String subject = "email@example.com";
+        VerifyPurpose purpose = VerifyPurpose.EMAIL;
+        Token issued = Token.builder().raw("verifyRaw").expiredAt(Instant.now().plusSeconds(300)).build();
+        when(tokenDomainService.issueVerifyToken(any(VerifyTokenIssueParam.class))).thenReturn(issued);
+
+        // when
+        Token result = service.issueVerifyToken(subject, purpose);
+
+        // then
+        assertThat(result).isEqualTo(issued);
+
+        ArgumentCaptor<VerifyTokenIssueParam> captor =
+                ArgumentCaptor.forClass(VerifyTokenIssueParam.class);
+        verify(tokenDomainService).issueVerifyToken(captor.capture());
+        assertThat(captor.getValue().subject()).isEqualTo(subject);
+        assertThat(captor.getValue().purpose()).isEqualTo(purpose);
+    }
+
+    @Test
+    @DisplayName("블랙리스트 등록 위임 확인")
+    void enrollBlacklist_Delegate_Test() {
+        // given
+        String raw = "refreshRaw";
+
+        // when
+        service.enrollBlacklist(raw);
+
+        // then
+        verify(tokenDomainService).enrollBlacklist(raw);
+    }
+
+    @Test
+    @DisplayName("토큰 탈취 차단 위임 확인: 블랙리스트 등록 + UUID 재발급 트리거")
+    void blockSnatchedToken_Delegate_Test() {
+        // given
+        String raw = "stolen-refresh";
+
+        // when
+        service.blockSnatchedToken(raw);
+
+        // then
+        verify(tokenDomainService).blockTokenUser(raw);
+    }
+}

--- a/src/test/java/com/simpleboard/board/auth/application/service/UserAuthCommandServiceTest.java
+++ b/src/test/java/com/simpleboard/board/auth/application/service/UserAuthCommandServiceTest.java
@@ -1,0 +1,120 @@
+package com.simpleboard.board.auth.application.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.simpleboard.board.auth.application.dto.request.EmailMemberRegisterCommand;
+import com.simpleboard.board.auth.application.exception.UserNotFoundException;
+import com.simpleboard.board.auth.domain.auth.dto.request.RegisterParams;
+import com.simpleboard.board.auth.domain.auth.entity.UserAuth;
+import com.simpleboard.board.auth.domain.auth.repository.UserAuthCommandRepository;
+import com.simpleboard.board.auth.domain.auth.vo.RegisterType;
+import com.simpleboard.board.auth.domain.auth.vo.UserState;
+import com.simpleboard.board.auth.domain.common.vo.Role;
+import com.simpleboard.board.auth.domain.token.dto.response.VerifyTokenInfo;
+import com.simpleboard.board.auth.domain.token.service.TokenDomainService;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class UserAuthCommandServiceTest {
+
+    private TokenDomainService tokenDomainService;
+    private UserAuthCommandRepository authCommandRepository;
+    private UserAuthCommandService service;
+
+    @BeforeEach
+    void setUp() {
+        tokenDomainService = mock(TokenDomainService.class);
+        authCommandRepository = mock(UserAuthCommandRepository.class);
+        service = new UserAuthCommandServiceImpl(tokenDomainService, authCommandRepository);
+    }
+
+    @Test
+    @DisplayName("Email 회원가입 성공: Verify 토큰 파싱 → EmailUserAuth 생성/저장")
+    void emailMemberRegister_Success_Test() {
+        // given
+        String emailTokenRaw = "emailToken";
+        String nicknameTokenRaw = "nicknameToken";
+        String email = "user@example.com";
+        String nickname = "snoopy";
+        String password = "pw1234";
+
+        when(tokenDomainService.validateAndParseVerifyToken(emailTokenRaw))
+                .thenReturn(VerifyTokenInfo.builder().subject(email).build());
+        when(tokenDomainService.validateAndParseVerifyToken(nicknameTokenRaw))
+                .thenReturn(VerifyTokenInfo.builder().subject(nickname).build());
+
+        // save가 무엇을 반환하든 상관없지만, 자연스럽게 save 인자로 받은 것을 그대로 반환
+        when(authCommandRepository.save(any(UserAuth.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        EmailMemberRegisterCommand cmd =
+                EmailMemberRegisterCommand.builder()
+                        .emailTokenRaw(emailTokenRaw)
+                        .nicknameTokenRaw(nicknameTokenRaw)
+                        .password(password)
+                        .gender("M")
+                        .birthYear(1997)
+                        .build();
+
+        // when
+        service.emailMemberRegister(cmd);
+
+        // then
+        verify(tokenDomainService).validateAndParseVerifyToken(emailTokenRaw);
+        verify(tokenDomainService).validateAndParseVerifyToken(nicknameTokenRaw);
+
+        ArgumentCaptor<UserAuth> captor = ArgumentCaptor.forClass(UserAuth.class);
+        verify(authCommandRepository).save(captor.capture());
+
+        UserAuth saved = captor.getValue();
+        // 생성된 Aggregate의 스냅샷 검증
+        assertThat(saved.getRegisterType()).isEqualTo(RegisterType.EMAIL);
+        assertThat(saved.getRole()).isEqualTo(Role.MEMBER);
+        assertThat(saved.getUserState()).isEqualTo(UserState.ACTIVE);
+        assertThat(saved.getLoginId()).isEqualTo(email);     // EmailUserAuth의 loginId는 email
+        assertThat(saved.getPassword()).isEqualTo(password); // EmailUserAuth의 password
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 성공: ACTIVE → DELETED 전이 및 저장 호출")
+    void deactivateAccount_Success_Test() {
+        // given
+        Long memberId = 42L;
+        UserAuth active =
+                UserAuth.register(
+                        RegisterParams.builder()
+                                .registerType(RegisterType.EMAIL)
+                                .role(Role.MEMBER)
+                                .email("user@example.com")
+                                .password("pw")
+                                .build());
+        when(authCommandRepository.findById(memberId)).thenReturn(Optional.of(active));
+        when(authCommandRepository.save(any(UserAuth.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        service.deactivateAccount(memberId);
+
+        // then
+        assertThat(active.getUserState()).isEqualTo(UserState.DELETED);
+        verify(authCommandRepository).save(active);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 실패: 대상 사용자를 찾을 수 없으면 UserNotFoundException")
+    void deactivateAccount_NotFound_Fail_Test() {
+        // given
+        Long memberId = 99L;
+        when(authCommandRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> service.deactivateAccount(memberId))
+                .isInstanceOf(UserNotFoundException.class);
+        verify(authCommandRepository, never()).save(any());
+    }
+}

--- a/src/test/java/com/simpleboard/board/auth/domain/token/service/TokenDomainServiceTest.java
+++ b/src/test/java/com/simpleboard/board/auth/domain/token/service/TokenDomainServiceTest.java
@@ -102,7 +102,7 @@ class TokenDomainServiceTest {
     Token dummy = Token.builder().raw("v").expiredAt(now.plus(ttl)).build();
     when(tokenProvider.issueToken(any(TokenClaims.class))).thenReturn(dummy);
 
-    VerifyTokenIssueParam cmd = new VerifyTokenIssueParam(purpose, subject, ttl);
+    VerifyTokenIssueParam cmd = new VerifyTokenIssueParam(purpose, subject);
 
     // when
     Token result = service.issueVerifyToken(cmd);


### PR DESCRIPTION
<!-- 제목은 `[도메인] PR 제목`으로 작성해주세요. (ex) [User] 소셜 로그인 필터 리팩토링 -->
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- Authentication Controller 개발
- UserAuth 관련 Api Controller 개발
- UserAuthCommandService 개발
- TokenApplicationService 개발

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->
컨트롤러를 두가지로 나누었습니다.
- 토큰, 인증관련 API를 담당하는 Authentication Controller
- 회원의 인증 정보를 담당하는 UserAuth 관련 UserAuthController
모든 API를 하나의 컨트롤러에 몰아넣는것은 무리라고 생각했지만, 막상 나누려고 하니 기준을 세우기가 애매하더라고요.
결국 **토큰과 관련된 기능을 수행** 과 **UserAuth aggregate 관련 기능 수행** 으로 나누었습니다.
다른 기준이 생각나신다면 편하게 제안해주세요.

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed #103 
