### PR TITLE
[Comment] Comment 정렬용 컬럼 추가

### DIFF
--- a/src/main/java/com/simpleboard/board/board/infrastructure/jpa/converter/CommentConverter.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/jpa/converter/CommentConverter.java
@@ -59,8 +59,10 @@ public class CommentConverter {
       MemberCommentEntity memberCommentEntity = (MemberCommentEntity) commentEntity;
       return MemberComment.builder()
           .id(commentEntity.getId())
-          .parentId((commentEntity.getParentId() == null  ||
-                  commentEntity.getParentId() == 0 )? null : commentEntity.getParentId())
+          .parentId(
+              (commentEntity.getParentId() == null || commentEntity.getParentId() == 0)
+                  ? null
+                  : commentEntity.getParentId())
           .postId(commentEntity.getPostId())
           .content(commentEntity.getContent())
           .commentState(commentEntity.getCommentState())

--- a/src/main/java/com/simpleboard/board/board/infrastructure/jpa/converter/CommentConverter.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/jpa/converter/CommentConverter.java
@@ -16,7 +16,7 @@ public class CommentConverter {
       GuestComment guestComment = (GuestComment) comment;
       return GuestCommentEntity.builder()
           .id(comment.getId())
-          .parentId(comment.getParentId())
+          .parentId(comment.getParentId() == null ? 0L : comment.getParentId())
           .postId(comment.getPostId())
           .content(comment.getContent())
           .commentState(comment.getCommentState())
@@ -29,7 +29,7 @@ public class CommentConverter {
       MemberComment memberComment = (MemberComment) comment;
       return MemberCommentEntity.builder()
           .id(comment.getId())
-          .parentId(comment.getParentId())
+          .parentId(comment.getParentId() == null ? 0L : comment.getParentId())
           .postId(comment.getPostId())
           .content(comment.getContent())
           .commentState(comment.getCommentState())
@@ -46,7 +46,7 @@ public class CommentConverter {
       GuestCommentEntity guestCommentEntity = (GuestCommentEntity) commentEntity;
       return GuestComment.builder()
           .id(commentEntity.getId())
-          .parentId(commentEntity.getParentId())
+          .parentId(commentEntity.getParentId() == 0 ? null : commentEntity.getParentId())
           .postId(commentEntity.getPostId())
           .content(commentEntity.getContent())
           .commentState(commentEntity.getCommentState())
@@ -59,7 +59,8 @@ public class CommentConverter {
       MemberCommentEntity memberCommentEntity = (MemberCommentEntity) commentEntity;
       return MemberComment.builder()
           .id(commentEntity.getId())
-          .parentId(commentEntity.getParentId())
+          .parentId((commentEntity.getParentId() == null  ||
+                  commentEntity.getParentId() == 0 )? null : commentEntity.getParentId())
           .postId(commentEntity.getPostId())
           .content(commentEntity.getContent())
           .commentState(commentEntity.getCommentState())

--- a/src/main/java/com/simpleboard/board/board/infrastructure/jpa/entity/CommentEntity.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/jpa/entity/CommentEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
@@ -13,7 +14,9 @@ import lombok.experimental.SuperBuilder;
 @DiscriminatorColumn(name = "COMMENT_TYPE")
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "COMMENT")
+@Table(
+    name = "COMMENT",
+    uniqueConstraints = {@UniqueConstraint(columnNames = {"PARENT_ID", "SIBLING_SEQ"})})
 @SuperBuilder
 @Getter
 public abstract class CommentEntity extends BaseEntity {
@@ -33,4 +36,6 @@ public abstract class CommentEntity extends BaseEntity {
 
   @Column(nullable = false)
   private CommentState commentState;
+
+  @Setter private Integer siblingSeq;
 }

--- a/src/main/java/com/simpleboard/board/board/infrastructure/jpa/repository/CommentCommandRepositoryImpl.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/jpa/repository/CommentCommandRepositoryImpl.java
@@ -6,6 +6,9 @@ import com.simpleboard.board.board.infrastructure.jpa.converter.CommentConverter
 import com.simpleboard.board.board.infrastructure.jpa.entity.CommentEntity;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 /**
@@ -19,13 +22,35 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class CommentCommandRepositoryImpl implements CommentCommandRepository {
 
+  private static final Logger log = LoggerFactory.getLogger(CommentCommandRepositoryImpl.class);
   private final CommentEntityRepository commentEntityRepository;
   private final CommentConverter converter;
 
+  private final Integer RETRY_LIMIT = 10;
+
   @Override
   public Comment save(Comment comment) {
-    CommentEntity saved = commentEntityRepository.save(converter.toJpaEntity(comment));
-    return converter.toDomainEntity(saved);
+    if (comment.getId() != null) {
+      CommentEntity saved = commentEntityRepository.save(converter.toJpaEntity(comment));
+      return converter.toDomainEntity(saved);
+    }
+    CommentEntity entity = converter.toJpaEntity(comment);
+
+    int attempt = 0;
+    while (true) {
+      try {
+        Integer lastSeq = commentEntityRepository.maxSiblingSeqByParentId(entity.getParentId());
+        lastSeq = lastSeq != null ? lastSeq : 0;
+
+        entity.setSiblingSeq(lastSeq + 1);
+
+        return converter.toDomainEntity(commentEntityRepository.save(entity));
+      } catch (DataIntegrityViolationException e) {
+        attempt++;
+        if (attempt >= RETRY_LIMIT) throw e;
+        log.info("Parent ID: {}  Attempt {}/{} failed", comment.getParentId(), attempt, RETRY_LIMIT);
+      }
+    }
   }
 
   @Override

--- a/src/main/java/com/simpleboard/board/board/infrastructure/jpa/repository/CommentCommandRepositoryImpl.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/jpa/repository/CommentCommandRepositoryImpl.java
@@ -48,7 +48,8 @@ public class CommentCommandRepositoryImpl implements CommentCommandRepository {
       } catch (DataIntegrityViolationException e) {
         attempt++;
         if (attempt >= RETRY_LIMIT) throw e;
-        log.info("Parent ID: {}  Attempt {}/{} failed", comment.getParentId(), attempt, RETRY_LIMIT);
+        log.info(
+            "Parent ID: {}  Attempt {}/{} failed", comment.getParentId(), attempt, RETRY_LIMIT);
       }
     }
   }

--- a/src/main/java/com/simpleboard/board/board/infrastructure/jpa/repository/CommentEntityRepository.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/jpa/repository/CommentEntityRepository.java
@@ -3,6 +3,7 @@ package com.simpleboard.board.board.infrastructure.jpa.repository;
 import com.simpleboard.board.board.infrastructure.jpa.entity.CommentEntity;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 /**
  * <b>Comment aggregate의 JPA 레포지토리</b>
@@ -14,4 +15,9 @@ public interface CommentEntityRepository extends JpaRepository<CommentEntity, Lo
   Optional<CommentEntity> findById(Long aLong);
 
   CommentEntity save(CommentEntity commentEntity);
+
+  @Query(
+      "select c.siblingSeq from CommentEntity c where c.parentId = :parentId"
+          + " order by c.siblingSeq desc limit 1")
+  Integer maxSiblingSeqByParentId(Long parentId);
 }

--- a/src/test/java/com/simpleboard/board/board/domain/comment/repository/CommentCommandRepositoryTest.java
+++ b/src/test/java/com/simpleboard/board/board/domain/comment/repository/CommentCommandRepositoryTest.java
@@ -12,12 +12,17 @@ import com.simpleboard.board.board.domain.comment.vo.CommentType;
 import com.simpleboard.board.board.domain.common.vo.Visitor;
 import com.simpleboard.board.board.domain.common.vo.VisitorType;
 import com.simpleboard.board.board.infrastructure.jpa.converter.CommentConverter;
+import com.simpleboard.board.board.infrastructure.jpa.entity.CommentEntity;
 import com.simpleboard.board.board.infrastructure.jpa.repository.CommentCommandRepositoryImpl;
+import com.simpleboard.board.board.infrastructure.jpa.repository.CommentEntityRepository;
 import com.simpleboard.board.testconfig.JpaAuditTestConfig;
-import java.util.Optional;
+import java.util.*;
+import java.util.concurrent.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -33,7 +38,9 @@ import org.springframework.test.context.ActiveProfiles;
 @Import({CommentCommandRepositoryImpl.class, CommentConverter.class, JpaAuditTestConfig.class})
 class CommentCommandRepositoryTest {
 
+  private static final Logger log = LoggerFactory.getLogger(CommentCommandRepositoryTest.class);
   @Autowired CommentCommandRepository repository;
+  @Autowired CommentEntityRepository entityRepository;
 
   @Nested
   @DisplayName("save")
@@ -131,6 +138,113 @@ class CommentCommandRepositoryTest {
     }
   }
 
+  @Nested
+  @DisplayName("Insert Concurrency")
+  class ConcurrencyTest {
+
+    private final int THREADS = 10;
+
+    @Test
+    @DisplayName("sibling_seq 동시성 테스트 - Root Comment")
+    void insert_parent_comment_at_once() throws InterruptedException {
+
+      ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+      CyclicBarrier startLine = new CyclicBarrier(THREADS);
+      CountDownLatch done = new CountDownLatch(THREADS);
+
+      List<Future<Long>> futures = new ArrayList<>(THREADS);
+
+      for (int i = 0; i < THREADS; i++) {
+        futures.add(
+            pool.submit(
+                () -> {
+                  try {
+                    startLine.await(100, TimeUnit.MILLISECONDS);
+                  } catch (Exception ignored) {
+                    log.debug("setting error");
+                  }
+                  try {
+                    Comment comment = Comment.write(guestParams());
+                    return repository.save(comment).getId();
+                  } catch (Exception e) {
+                    e.printStackTrace();
+                    throw e;
+                  } finally {
+                    done.countDown();
+                  }
+                }));
+      }
+
+      done.await(1, TimeUnit.SECONDS);
+      pool.shutdown();
+
+      assertThat(futures.stream().filter(f -> !f.isDone()).count()).isEqualTo(0);
+
+      Set<Integer> set = new HashSet<>();
+      entityRepository.findAll().stream()
+          .forEach(
+              c -> {
+                assertThat(set.contains(c.getSiblingSeq())).isFalse();
+                set.add(c.getSiblingSeq());
+              });
+      assertThat(set.size()).isEqualTo(THREADS);
+    }
+
+    @Test
+    @DisplayName("sibling_seq 동시성 테스트 - Child Comment")
+    void insert_child_comment_at_once() throws InterruptedException {
+
+      ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+      CyclicBarrier startLine = new CyclicBarrier(THREADS);
+      CountDownLatch done = new CountDownLatch(THREADS);
+
+      List<Future<Long>> futures = new ArrayList<>(THREADS);
+
+      Comment parent = Comment.write(guestParams());
+      Comment saved = repository.save(parent);
+      Long parentId = saved.getId();
+
+      for (int i = 0; i < THREADS; i++) {
+        futures.add(
+            pool.submit(
+                () -> {
+                  try {
+                    startLine.await(100, TimeUnit.MILLISECONDS);
+                  } catch (Exception ignored) {
+                    log.debug("setting error");
+                  }
+                  try {
+                    Comment comment = Comment.write(guestParams(parentId));
+                    return repository.save(comment).getId();
+                  } catch (Exception e) {
+                    e.printStackTrace();
+                    throw e;
+                  } finally {
+                    done.countDown();
+                  }
+                }));
+      }
+
+      done.await(1, TimeUnit.SECONDS);
+      pool.shutdown();
+
+      Set<Integer> set = new HashSet<>();
+      List<CommentEntity> all = entityRepository.findAll();
+
+      assertThat(futures.stream().filter(f -> !f.isDone()).count()).isEqualTo(0);
+
+      all.stream()
+          .filter(c -> c.getParentId().equals(parentId))
+          .forEach(
+              c -> {
+                assertThat(set.contains(c.getSiblingSeq())).isFalse();
+                set.add(c.getSiblingSeq());
+              });
+
+      assertThat(set.size()).isEqualTo(THREADS);
+    }
+  }
+
   private CommentCreateParams guestParams() {
     return CommentCreateParams.builder()
         .postId(100L)
@@ -138,6 +252,17 @@ class CommentCommandRepositoryTest {
         .content("hello-guest")
         .commentType(CommentType.GUEST)
         .nickname("게스트닉")
+        .password("pass-1234")
+        .build();
+  }
+
+  private CommentCreateParams guestParams(Long parentId) {
+    return CommentCreateParams.builder()
+        .postId(100L)
+        .parentCommentId(parentId)
+        .content("hello-guest-child")
+        .commentType(CommentType.GUEST)
+        .nickname("child")
         .password("pass-1234")
         .build();
   }

--- a/src/test/java/com/simpleboard/board/board/infrastructure/jpa/converter/CommentConverterUnitTest.java
+++ b/src/test/java/com/simpleboard/board/board/infrastructure/jpa/converter/CommentConverterUnitTest.java
@@ -87,7 +87,7 @@ class CommentConverterUnitTest {
     assertThat(entity).isInstanceOf(MemberCommentEntity.class);
     MemberCommentEntity me = (MemberCommentEntity) entity;
     assertThat(me.getId()).isEqualTo(202L);
-    assertThat(me.getParentId()).isNull();
+    assertThat(me.getParentId()).isEqualTo(0);
     assertThat(me.getPostId()).isEqualTo(33L);
     assertThat(me.getContent()).isEqualTo("member content");
     assertThat(me.getCommentState()).isEqualTo(CommentState.ACTIVATE);


### PR DESCRIPTION
<!-- 제목은 `[도메인] PR 제목`으로 작성해주세요. (ex) [User] 소셜 로그인 필터 리팩토링 -->
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- 목록 조회시 정렬을 위한 컬럼 sibling_seq 추가
- 생성시 sibling_seq 할당 로직 추가

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->
Comment 생성시 CommentEntity.sibling_seq 컬럼에 MAX+1 생성을 하여야 하는데, 이때 race condition이 발생합니다.
이를 해결하는 방법으로 PARENT_ID와 SIBLING_SEQ 컬럼에 UNIQUE 제약조건을 걸고, Confilct 발생시 다시 MAX 값을 조회, MAX+1값 INSERT를 하도록 하였습니다.
lock을 사용해 해결해보고 싶었는데 예기치 못한 문제들이 너무 많이 발생하더라고요...
혹시 더 좋은 해결 방법이 있다면 제안 부탁드립니다.

### 📝 메모
<!-- PR 관련 전달사항이 있다면 이곳에 작성해주세요. -->
Command쪽 수정사항임에도 Query 개발 이슈를 달아놓은 이유는 이 수정이 순수하게 Query시(목록 조회시) 정렬을 위한 수정이기 때문입니다.

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
#124 