### PR TITLE
[Comment] Query - 목록조회 개발

### DIFF
--- a/src/main/java/com/simpleboard/board/board/application/converter/CommentQueryServiceRepoConverter.java
+++ b/src/main/java/com/simpleboard/board/board/application/converter/CommentQueryServiceRepoConverter.java
@@ -4,10 +4,16 @@ import com.simpleboard.board.board.application.dto.request.CommentListQuery;
 import com.simpleboard.board.board.application.dto.response.CommentListQueryResult;
 import com.simpleboard.board.board.application.query.CommentListCriteria;
 import com.simpleboard.board.board.application.query.CommentListReadModel;
+import com.simpleboard.board.board.domain.comment.vo.CommentType;
+import java.util.Map;
 import org.springframework.stereotype.Component;
 
 /**
- * <b>Post query service <-> repository 컨버터</b>
+ * <b>Comment query service <-> repository 컨버터</b>
+ *
+ * <ul>
+ *   <li>Member Comment의 writer nickname 매핑 수행
+ * </ul>
  *
  * @version 1.0
  */
@@ -20,7 +26,11 @@ public class CommentQueryServiceRepoConverter {
    **************************/
 
   public CommentListCriteria getCriteria(CommentListQuery query) {
-    return null;
+    return CommentListCriteria.builder()
+        .postId(query.postId())
+        .page(query.page())
+        .size(query.size())
+        .build();
   }
 
   /**************************
@@ -28,7 +38,42 @@ public class CommentQueryServiceRepoConverter {
    * Service <- Repository
    **************************/
 
-  public CommentListQueryResult getQueryResult(CommentListReadModel readModel) {
-    return null;
+  /**
+   * <b>Comment 응답 컨버터 메서드</b>
+   *
+   * <p>Member Comment의 nickname을 삽입
+   *
+   * @since 1.0
+   */
+  public CommentListQueryResult getQueryResult(
+      CommentListReadModel readModel, Map<Long, String> nicknameMap) {
+    return CommentListQueryResult.builder()
+        .activeComments(readModel.activeComments())
+        .currentPage(readModel.currentPage())
+        .totalPages(readModel.totalPages())
+        .nextPage(readModel.nextPage())
+        .size(readModel.size())
+        .comments(
+            readModel.comments().stream()
+                .map(
+                    (summary) ->
+                        CommentListQueryResult.CommentSummary.builder()
+                            .commentState(summary.commentState())
+                            .commentId(summary.commentId())
+                            .parentId(summary.parentId())
+                            .commentType(summary.commentType())
+                            .content(summary.content())
+                            .nickname(
+                                summary.commentType().equals(CommentType.GUEST)
+                                    ? summary.nickname()
+                                    : nicknameMap.get(summary.writerId()))
+                            .writerId(summary.writerId())
+                            .createdAt(summary.createdAt())
+                            .updatedAt(summary.updatedAt())
+                            .siblingSeq(summary.siblingSeq())
+                            .depth(summary.depth())
+                            .build())
+                .toList())
+        .build();
   }
 }

--- a/src/main/java/com/simpleboard/board/board/application/dto/request/CommentListQuery.java
+++ b/src/main/java/com/simpleboard/board/board/application/dto/request/CommentListQuery.java
@@ -10,4 +10,4 @@ import lombok.Builder;
  * @domain request-dto
  */
 @Builder
-public record CommentListQuery() {}
+public record CommentListQuery(Long postId, int page, int size) {}

--- a/src/main/java/com/simpleboard/board/board/application/dto/response/CommentListQueryResult.java
+++ b/src/main/java/com/simpleboard/board/board/application/dto/response/CommentListQueryResult.java
@@ -1,5 +1,9 @@
 package com.simpleboard.board.board.application.dto.response;
 
+import com.simpleboard.board.board.domain.comment.vo.CommentState;
+import com.simpleboard.board.board.domain.comment.vo.CommentType;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
 
 /**
@@ -10,4 +14,24 @@ import lombok.Builder;
  * @domain response-dto
  */
 @Builder
-public record CommentListQueryResult() {}
+public record CommentListQueryResult(
+    long activeComments,
+    int totalPages,
+    int currentPage,
+    int nextPage,
+    int size,
+    List<CommentSummary> comments) {
+  @Builder
+  public record CommentSummary(
+      CommentState commentState,
+      Long commentId,
+      Long parentId,
+      CommentType commentType,
+      String content,
+      String nickname,
+      Long writerId,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt,
+      Integer siblingSeq,
+      Integer depth) {}
+}

--- a/src/main/java/com/simpleboard/board/board/application/query/CommentListCriteria.java
+++ b/src/main/java/com/simpleboard/board/board/application/query/CommentListCriteria.java
@@ -10,4 +10,4 @@ import lombok.Builder;
  * @domain request-dto
  */
 @Builder
-public record CommentListCriteria() {}
+public record CommentListCriteria(Long postId, int page, int size) {}

--- a/src/main/java/com/simpleboard/board/board/application/query/CommentListReadModel.java
+++ b/src/main/java/com/simpleboard/board/board/application/query/CommentListReadModel.java
@@ -1,5 +1,9 @@
 package com.simpleboard.board.board.application.query;
 
+import com.simpleboard.board.board.domain.comment.vo.CommentState;
+import com.simpleboard.board.board.domain.comment.vo.CommentType;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
 
 /**
@@ -10,4 +14,24 @@ import lombok.Builder;
  * @domain response-dto
  */
 @Builder
-public record CommentListReadModel() {}
+public record CommentListReadModel(
+    long activeComments,
+    int totalPages,
+    int currentPage,
+    int nextPage,
+    int size,
+    List<CommentSummary> comments) {
+  @Builder
+  public record CommentSummary(
+      CommentState commentState,
+      Long commentId,
+      Long parentId,
+      CommentType commentType,
+      String content,
+      String nickname,
+      Long writerId,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt,
+      Integer siblingSeq,
+      Integer depth) {}
+}

--- a/src/main/java/com/simpleboard/board/board/application/service/CommentQueryServiceImpl.java
+++ b/src/main/java/com/simpleboard/board/board/application/service/CommentQueryServiceImpl.java
@@ -2,8 +2,14 @@ package com.simpleboard.board.board.application.service;
 
 import com.simpleboard.board.board.application.converter.CommentQueryServiceRepoConverter;
 import com.simpleboard.board.board.application.dto.request.CommentListQuery;
+import com.simpleboard.board.board.application.dto.response.AuthorSummary;
 import com.simpleboard.board.board.application.dto.response.CommentListQueryResult;
+import com.simpleboard.board.board.application.query.CommentListReadModel;
 import com.simpleboard.board.board.application.query.CommentQueryRepository;
+import com.simpleboard.board.board.domain.post.vo.PostTypeEnum;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,8 +20,29 @@ public class CommentQueryServiceImpl implements CommentQueryService {
   private final CommentQueryServiceRepoConverter converter;
   private final MemberFetchService memberFetchService;
 
+  /**
+   * <b>Comment 목록 조회 USECASE</b>
+   *
+   * <ul>
+   *   <li>QueryRepository에서 Comment 목록 조회 수행
+   *   <li>MemberComment의 nickname을 Member B.C에서 조회 후 매핑
+   * </ul>
+   *
+   * @since 1.0
+   */
   @Override
   public CommentListQueryResult getCommentList(CommentListQuery query) {
-    return null;
+    CommentListReadModel readModel =
+        commentQueryRepository.getCommentList(converter.getCriteria(query));
+    List<Long> writerIds =
+        readModel.comments().stream()
+            .filter(c -> c.commentType().equals(PostTypeEnum.MEMBER))
+            .map(c -> c.writerId())
+            .toList();
+    Map<Long, String> nicknameMap =
+        memberFetchService.fetchAuthorSummaryList(writerIds).stream()
+            .collect(Collectors.toMap(AuthorSummary::authorId, summary -> summary.nickname()));
+
+    return converter.getQueryResult(readModel, nicknameMap);
   }
 }

--- a/src/main/java/com/simpleboard/board/board/infrastructure/jpa/converter/CommentConverter.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/jpa/converter/CommentConverter.java
@@ -59,8 +59,10 @@ public class CommentConverter {
       MemberCommentEntity memberCommentEntity = (MemberCommentEntity) commentEntity;
       return MemberComment.builder()
           .id(commentEntity.getId())
-          .parentId((commentEntity.getParentId() == null  ||
-                  commentEntity.getParentId() == 0 )? null : commentEntity.getParentId())
+          .parentId(
+              (commentEntity.getParentId() == null || commentEntity.getParentId() == 0)
+                  ? null
+                  : commentEntity.getParentId())
           .postId(commentEntity.getPostId())
           .content(commentEntity.getContent())
           .commentState(commentEntity.getCommentState())

--- a/src/main/java/com/simpleboard/board/board/infrastructure/jpa/converter/CommentConverter.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/jpa/converter/CommentConverter.java
@@ -16,7 +16,7 @@ public class CommentConverter {
       GuestComment guestComment = (GuestComment) comment;
       return GuestCommentEntity.builder()
           .id(comment.getId())
-          .parentId(comment.getParentId())
+          .parentId(comment.getParentId() == null ? 0L : comment.getParentId())
           .postId(comment.getPostId())
           .content(comment.getContent())
           .commentState(comment.getCommentState())
@@ -29,7 +29,7 @@ public class CommentConverter {
       MemberComment memberComment = (MemberComment) comment;
       return MemberCommentEntity.builder()
           .id(comment.getId())
-          .parentId(comment.getParentId())
+          .parentId(comment.getParentId() == null ? 0L : comment.getParentId())
           .postId(comment.getPostId())
           .content(comment.getContent())
           .commentState(comment.getCommentState())
@@ -46,7 +46,7 @@ public class CommentConverter {
       GuestCommentEntity guestCommentEntity = (GuestCommentEntity) commentEntity;
       return GuestComment.builder()
           .id(commentEntity.getId())
-          .parentId(commentEntity.getParentId())
+          .parentId(commentEntity.getParentId() == 0 ? null : commentEntity.getParentId())
           .postId(commentEntity.getPostId())
           .content(commentEntity.getContent())
           .commentState(commentEntity.getCommentState())
@@ -59,7 +59,8 @@ public class CommentConverter {
       MemberCommentEntity memberCommentEntity = (MemberCommentEntity) commentEntity;
       return MemberComment.builder()
           .id(commentEntity.getId())
-          .parentId(commentEntity.getParentId())
+          .parentId((commentEntity.getParentId() == null  ||
+                  commentEntity.getParentId() == 0 )? null : commentEntity.getParentId())
           .postId(commentEntity.getPostId())
           .content(commentEntity.getContent())
           .commentState(commentEntity.getCommentState())

--- a/src/main/java/com/simpleboard/board/board/infrastructure/jpa/entity/CommentEntity.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/jpa/entity/CommentEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
@@ -13,7 +14,9 @@ import lombok.experimental.SuperBuilder;
 @DiscriminatorColumn(name = "COMMENT_TYPE")
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "COMMENT")
+@Table(
+    name = "COMMENT",
+    uniqueConstraints = {@UniqueConstraint(columnNames = {"PARENT_ID", "SIBLING_SEQ"})})
 @SuperBuilder
 @Getter
 public abstract class CommentEntity extends BaseEntity {
@@ -33,4 +36,6 @@ public abstract class CommentEntity extends BaseEntity {
 
   @Column(nullable = false)
   private CommentState commentState;
+
+  @Setter private Integer siblingSeq;
 }

--- a/src/main/java/com/simpleboard/board/board/infrastructure/jpa/repository/CommentCommandRepositoryImpl.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/jpa/repository/CommentCommandRepositoryImpl.java
@@ -6,6 +6,9 @@ import com.simpleboard.board.board.infrastructure.jpa.converter.CommentConverter
 import com.simpleboard.board.board.infrastructure.jpa.entity.CommentEntity;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 /**
@@ -19,13 +22,35 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class CommentCommandRepositoryImpl implements CommentCommandRepository {
 
+  private static final Logger log = LoggerFactory.getLogger(CommentCommandRepositoryImpl.class);
   private final CommentEntityRepository commentEntityRepository;
   private final CommentConverter converter;
 
+  private final Integer RETRY_LIMIT = 10;
+
   @Override
   public Comment save(Comment comment) {
-    CommentEntity saved = commentEntityRepository.save(converter.toJpaEntity(comment));
-    return converter.toDomainEntity(saved);
+    if (comment.getId() != null) {
+      CommentEntity saved = commentEntityRepository.save(converter.toJpaEntity(comment));
+      return converter.toDomainEntity(saved);
+    }
+    CommentEntity entity = converter.toJpaEntity(comment);
+
+    int attempt = 0;
+    while (true) {
+      try {
+        Integer lastSeq = commentEntityRepository.maxSiblingSeqByParentId(entity.getParentId());
+        lastSeq = lastSeq != null ? lastSeq : 0;
+
+        entity.setSiblingSeq(lastSeq + 1);
+
+        return converter.toDomainEntity(commentEntityRepository.save(entity));
+      } catch (DataIntegrityViolationException e) {
+        attempt++;
+        if (attempt >= RETRY_LIMIT) throw e;
+        log.info("Parent ID: {}  Attempt {}/{} failed", comment.getParentId(), attempt, RETRY_LIMIT);
+      }
+    }
   }
 
   @Override

--- a/src/main/java/com/simpleboard/board/board/infrastructure/jpa/repository/CommentCommandRepositoryImpl.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/jpa/repository/CommentCommandRepositoryImpl.java
@@ -48,7 +48,8 @@ public class CommentCommandRepositoryImpl implements CommentCommandRepository {
       } catch (DataIntegrityViolationException e) {
         attempt++;
         if (attempt >= RETRY_LIMIT) throw e;
-        log.info("Parent ID: {}  Attempt {}/{} failed", comment.getParentId(), attempt, RETRY_LIMIT);
+        log.info(
+            "Parent ID: {}  Attempt {}/{} failed", comment.getParentId(), attempt, RETRY_LIMIT);
       }
     }
   }

--- a/src/main/java/com/simpleboard/board/board/infrastructure/jpa/repository/CommentEntityRepository.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/jpa/repository/CommentEntityRepository.java
@@ -3,6 +3,7 @@ package com.simpleboard.board.board.infrastructure.jpa.repository;
 import com.simpleboard.board.board.infrastructure.jpa.entity.CommentEntity;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 /**
  * <b>Comment aggregate의 JPA 레포지토리</b>
@@ -14,4 +15,9 @@ public interface CommentEntityRepository extends JpaRepository<CommentEntity, Lo
   Optional<CommentEntity> findById(Long aLong);
 
   CommentEntity save(CommentEntity commentEntity);
+
+  @Query(
+      "select c.siblingSeq from CommentEntity c where c.parentId = :parentId"
+          + " order by c.siblingSeq desc limit 1")
+  Integer maxSiblingSeqByParentId(Long parentId);
 }

--- a/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/converter/CommentQueryConverter.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/converter/CommentQueryConverter.java
@@ -1,0 +1,80 @@
+package com.simpleboard.board.board.infrastructure.mybatis.converter;
+
+import com.simpleboard.board.board.application.query.CommentListCriteria;
+import com.simpleboard.board.board.application.query.CommentListReadModel;
+import com.simpleboard.board.board.domain.comment.vo.CommentState;
+import com.simpleboard.board.board.domain.comment.vo.CommentType;
+import com.simpleboard.board.board.infrastructure.mybatis.mapper.CommentListCondition;
+import com.simpleboard.board.board.infrastructure.mybatis.mapper.CommentSummaryData;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * <b>Repository <-> Mapper converter</b>
+ *
+ * <ul>
+ *   <li>Criteria -> Condition 으로 변환
+ *   <li>Data -> ReadModel 으로 변환
+ *   <li>0-based <-> 1-based 페이징 변환을 담당</->
+ * </ul>
+ */
+@Component
+public class CommentQueryConverter {
+
+  public CommentListCondition toCondition(CommentListCriteria criteria) {
+    int limit = criteria.size() != 0 ? criteria.size() : 10;
+    int zeroBasedPage = criteria.page() > 0 ? criteria.page() - 1 : 0;
+    return CommentListCondition.builder()
+        .postId(criteria.postId())
+        .limit(limit)
+        .offset(zeroBasedPage * limit)
+        .build();
+  }
+
+  /**
+   * <b>응답 반환 DTO</b>
+   *
+   * <ul>
+   *   <li>페이지 관련 정보 처리
+   *   <li>Enum type 매핑
+   * </ul>
+   *
+   * @since 1.0
+   */
+  public CommentListReadModel toReadModel(
+      List<CommentSummaryData> rows,
+      Long activeComments,
+      Long rootComments,
+      CommentListCondition condition) {
+
+    int totalPages =
+        (int) (rootComments / condition.limit()) + (rootComments % condition.limit() == 0 ? 0 : 1);
+    int oneBasedCurPage = condition.offset() / condition.limit() + 1;
+
+    return CommentListReadModel.builder()
+        .activeComments(activeComments)
+        .totalPages(totalPages)
+        .currentPage(oneBasedCurPage)
+        .nextPage(oneBasedCurPage + 1 < totalPages ? oneBasedCurPage + 1 : totalPages)
+        .size(condition.limit())
+        .comments(
+            rows.stream()
+                .map(
+                    row ->
+                        CommentListReadModel.CommentSummary.builder()
+                            .commentState(CommentState.valueOf(row.commentState()))
+                            .commentId(row.commentId())
+                            .parentId(row.parentId())
+                            .commentType(CommentType.valueOf(row.commentType().split("_")[0]))
+                            .content(row.content())
+                            .nickname(row.nickname())
+                            .writerId(row.writerId())
+                            .createdAt(row.createdAt())
+                            .updatedAt(row.updatedAt())
+                            .siblingSeq(row.siblingSeq())
+                            .depth(row.depth())
+                            .build())
+                .toList())
+        .build();
+  }
+}

--- a/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/mapper/CommentListCondition.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/mapper/CommentListCondition.java
@@ -1,0 +1,13 @@
+package com.simpleboard.board.board.infrastructure.mybatis.mapper;
+
+import lombok.Builder;
+
+/**
+ * <b>Comment 목록 조회 Condition</b>
+ *
+ * <p>Req: repository -> mapper
+ *
+ * @domain request-dto
+ */
+@Builder
+public record CommentListCondition(Long postId, int limit, int offset) {}

--- a/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/mapper/CommentQueryMapper.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/mapper/CommentQueryMapper.java
@@ -1,6 +1,8 @@
 package com.simpleboard.board.board.infrastructure.mybatis.mapper;
 
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 /**
  * <b>Mybatis용 Mapper 클래스</b>
@@ -8,4 +10,31 @@ import org.apache.ibatis.annotations.Mapper;
  * <p>Comment 조회 요청을 받아 xml 파일에 정의되어 있는 SQL 쿼리 실행
  */
 @Mapper
-public interface CommentQueryMapper {}
+public interface CommentQueryMapper {
+  List<CommentSummaryData> getCommentList(CommentListCondition condition);
+
+  /**
+   * <b>Active 상태의 Comment 수 조회</b>
+   *
+   * <ul>
+   *   <li>postId의 Post에 작성된 Active 상태의 Comment의 총 수 반환
+   *   <li>soft delete 상태의 Comment는 카운트하지 않음
+   * </ul>
+   *
+   * @since 1.0
+   */
+  Long countActiveComments(@Param("postId") Long postId);
+
+  /**
+   * <b>Root Comment 수 조회</b>
+   *
+   * <ul>
+   *   <li>postId의 Post에 작성된 Root Comment의 총 수 반환
+   *   <li>부모가 없는, 최상의 Comment만 카운트
+   *   <li>soft delete 상태의 Comment도 카운트
+   * </ul>
+   *
+   * @since 1.0
+   */
+  Long countRootComments(@Param("postId") Long postId);
+}

--- a/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/mapper/CommentSummaryData.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/mapper/CommentSummaryData.java
@@ -1,0 +1,27 @@
+package com.simpleboard.board.board.infrastructure.mybatis.mapper;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+/**
+ * <b>Comment 목록 조회 응답 모델</b>
+ *
+ * <p>단일 Comment에 대한 메타 정보를 담은 DTO
+ *
+ * <p>Res: repository <- mapper
+ *
+ * @domain response-dto
+ */
+@Builder
+public record CommentSummaryData(
+    String commentState,
+    Long commentId,
+    Long parentId,
+    String commentType,
+    String content,
+    String nickname,
+    Long writerId,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    Integer siblingSeq,
+    Integer depth) {}

--- a/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/repository/CommentQueryRepositoryImpl.java
+++ b/src/main/java/com/simpleboard/board/board/infrastructure/mybatis/repository/CommentQueryRepositoryImpl.java
@@ -3,7 +3,11 @@ package com.simpleboard.board.board.infrastructure.mybatis.repository;
 import com.simpleboard.board.board.application.query.CommentListCriteria;
 import com.simpleboard.board.board.application.query.CommentListReadModel;
 import com.simpleboard.board.board.application.query.CommentQueryRepository;
+import com.simpleboard.board.board.infrastructure.mybatis.converter.CommentQueryConverter;
+import com.simpleboard.board.board.infrastructure.mybatis.mapper.CommentListCondition;
 import com.simpleboard.board.board.infrastructure.mybatis.mapper.CommentQueryMapper;
+import com.simpleboard.board.board.infrastructure.mybatis.mapper.CommentSummaryData;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -11,9 +15,15 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class CommentQueryRepositoryImpl implements CommentQueryRepository {
   private final CommentQueryMapper commentQueryMapper;
+  private final CommentQueryConverter converter;
 
   @Override
   public CommentListReadModel getCommentList(CommentListCriteria criteria) {
-    return null;
+
+    CommentListCondition condition = converter.toCondition(criteria);
+    List<CommentSummaryData> commentList = commentQueryMapper.getCommentList(condition);
+    Long activeComments = commentQueryMapper.countActiveComments(criteria.postId());
+    Long rootComments = commentQueryMapper.countRootComments(criteria.postId());
+    return converter.toReadModel(commentList, activeComments, rootComments, condition);
   }
 }

--- a/src/main/java/com/simpleboard/board/board/presentation/converter/CommentQueryPresentationApplicationConverter.java
+++ b/src/main/java/com/simpleboard/board/board/presentation/converter/CommentQueryPresentationApplicationConverter.java
@@ -2,8 +2,10 @@ package com.simpleboard.board.board.presentation.converter;
 
 import com.simpleboard.board.board.application.dto.request.CommentListQuery;
 import com.simpleboard.board.board.application.dto.response.CommentListQueryResult;
+import com.simpleboard.board.board.domain.comment.vo.CommentState;
 import com.simpleboard.board.board.presentation.dto.request.CommentListQueryForm;
 import com.simpleboard.board.board.presentation.dto.response.CommentListQueryResponse;
+import com.simpleboard.board.board.presentation.dto.response.CommentListQueryResponse.CommentSummary.CommentSummaryBuilder;
 import org.springframework.stereotype.Component;
 
 /**
@@ -19,8 +21,8 @@ public class CommentQueryPresentationApplicationConverter {
    * presentation -> Service
    **************************/
 
-  public CommentListQuery toQuery(CommentListQueryForm form) {
-    return null;
+  public CommentListQuery toQuery(CommentListQueryForm form, Long postId) {
+    return CommentListQuery.builder().postId(postId).page(form.page()).size(form.size()).build();
   }
 
   /**************************
@@ -29,6 +31,38 @@ public class CommentQueryPresentationApplicationConverter {
    **************************/
 
   public CommentListQueryResponse toQueryResponse(CommentListQueryResult result) {
-    return null;
+    return CommentListQueryResponse.builder()
+        .totalComments(result.activeComments())
+        .page(result.nextPage())
+        .size(result.size())
+        .comments(
+            result.comments().stream()
+                .map(
+                    summary -> {
+                      CommentSummaryBuilder builder =
+                          CommentListQueryResponse.CommentSummary.builder();
+                      if (summary.commentState().equals(CommentState.ACTIVATE)) {
+                        builder
+                            .isDeleted(false)
+                            .commentId(summary.commentId())
+                            .parentId(summary.parentId())
+                            .commentType(summary.commentType().toString())
+                            .content(summary.content())
+                            .nickname(summary.nickname())
+                            .writerId(summary.writerId())
+                            .createdAt(summary.createdAt())
+                            .updatedAt(summary.updatedAt())
+                            .siblingSeq(summary.siblingSeq())
+                            .depth(summary.depth());
+                      } else {
+                        builder
+                            .isDeleted(true)
+                            .siblingSeq(summary.siblingSeq())
+                            .depth(summary.depth());
+                      }
+                      return builder.build();
+                    })
+                .toList())
+        .build();
   }
 }

--- a/src/main/java/com/simpleboard/board/board/presentation/dto/request/CommentListQueryForm.java
+++ b/src/main/java/com/simpleboard/board/board/presentation/dto/request/CommentListQueryForm.java
@@ -12,4 +12,4 @@ import lombok.Builder;
  * @domain request-dto
  */
 @Builder
-public record CommentListQueryForm() {}
+public record CommentListQueryForm(int page, int size) {}

--- a/src/main/java/com/simpleboard/board/board/presentation/dto/response/CommentListQueryResponse.java
+++ b/src/main/java/com/simpleboard/board/board/presentation/dto/response/CommentListQueryResponse.java
@@ -1,5 +1,9 @@
 package com.simpleboard.board.board.presentation.dto.response;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
 /**
  * Comment 목록 조회 응답 모델.
  *
@@ -7,4 +11,20 @@ package com.simpleboard.board.board.presentation.dto.response;
  *
  * @domain response-dto
  */
-public record CommentListQueryResponse() {}
+@Builder
+public record CommentListQueryResponse(
+    long totalComments, int page, int size, List<CommentSummary> comments) {
+  @Builder
+  public record CommentSummary(
+      Boolean isDeleted,
+      Long commentId,
+      Long parentId,
+      String commentType,
+      String content,
+      String nickname,
+      Long writerId,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt,
+      Integer siblingSeq,
+      Integer depth) {}
+}

--- a/src/main/java/com/simpleboard/board/board/presentation/web/CommentQueryController.java
+++ b/src/main/java/com/simpleboard/board/board/presentation/web/CommentQueryController.java
@@ -7,7 +7,6 @@ import com.simpleboard.board.board.presentation.dto.request.CommentListQueryForm
 import com.simpleboard.board.board.presentation.dto.response.CommentListQueryResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,16 +14,19 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Board - Comment API", description = "댓글 Read API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/comments")
 public class CommentQueryController {
 
   private final CommentQueryService commentQueryService;
   private final CommentQueryPresentationApplicationConverter converter;
 
   @Operation(summary = "댓글 목록 조회 API", description = "게시글에 대한 댓글 목록조회를 요청합니다.")
-  @GetMapping
+  @GetMapping("board/{boardId}/post/{postId}/comments")
   public ResponseEntity<CommentListQueryResponse> getCommentList(
-      @RequestBody @Valid CommentListQueryForm form) {
-    return ResponseEntity.ok(converter.toQueryResponse(CommentListQueryResult.builder().build()));
+      @PathVariable Long boardId,
+      @PathVariable Long postId,
+      @ModelAttribute CommentListQueryForm form) {
+    CommentListQueryResult commentList =
+        commentQueryService.getCommentList(converter.toQuery(form, postId));
+    return ResponseEntity.ok(converter.toQueryResponse(commentList));
   }
 }

--- a/src/test/java/com/simpleboard/board/board/application/converter/CommentQueryServiceRepoConverterTest.java
+++ b/src/test/java/com/simpleboard/board/board/application/converter/CommentQueryServiceRepoConverterTest.java
@@ -1,0 +1,133 @@
+package com.simpleboard.board.board.application.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.simpleboard.board.board.application.dto.request.CommentListQuery;
+import com.simpleboard.board.board.application.dto.response.CommentListQueryResult;
+import com.simpleboard.board.board.application.query.CommentListCriteria;
+import com.simpleboard.board.board.application.query.CommentListReadModel;
+import com.simpleboard.board.board.domain.comment.vo.CommentState;
+import com.simpleboard.board.board.domain.comment.vo.CommentType;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class CommentQueryServiceRepoConverterTest {
+
+  CommentQueryServiceRepoConverter converter = new CommentQueryServiceRepoConverter();
+
+  private CommentListReadModel.CommentSummary rmSummary(
+      long id,
+      Long parentId,
+      CommentType type,
+      String guestNickname,
+      Long writerId,
+      String content) {
+    return CommentListReadModel.CommentSummary.builder()
+        .commentState(CommentState.ACTIVATE)
+        .commentId(id)
+        .parentId(parentId)
+        .commentType(type)
+        .content(content)
+        .nickname(guestNickname)
+        .writerId(writerId)
+        .createdAt(LocalDateTime.parse("2025-02-01T10:00:00"))
+        .updatedAt(LocalDateTime.parse("2025-02-01T10:00:00"))
+        .siblingSeq(1)
+        .depth(0)
+        .build();
+  }
+
+  private CommentListReadModel readModel(List<CommentListReadModel.CommentSummary> rows) {
+    return CommentListReadModel.builder()
+        .activeComments(79L)
+        .currentPage(1)
+        .totalPages(4)
+        .nextPage(2)
+        .size(10)
+        .comments(rows)
+        .build();
+  }
+
+  @Nested
+  @DisplayName("getCriteria()")
+  class GetCriteria {
+    @Test
+    @DisplayName("Query → Criteria 필드 일대일 매핑")
+    void mapsQueryToCriteria() {
+      CommentListQuery query = CommentListQuery.builder().postId(300L).page(3).size(20).build();
+
+      CommentListCriteria c = converter.getCriteria(query);
+      assertThat(c.postId()).isEqualTo(300L);
+      assertThat(c.page()).isEqualTo(3);
+      assertThat(c.size()).isEqualTo(20);
+    }
+  }
+
+  @Nested
+  @DisplayName("getQueryResult()")
+  class GetQueryResult {
+
+    @Test
+    @DisplayName("GUEST는 원래 nickname 그대로, MEMBER는 nicknameMap을 사용")
+    void guestVsMemberNicknameSource() {
+      var rows =
+          List.of(
+              rmSummary(1L, 0L, CommentType.GUEST, "guest-alice", null, "g1"),
+              rmSummary(2L, 0L, CommentType.MEMBER, null, 701L, "m1"));
+      var rm = readModel(rows);
+
+      Map<Long, String> nicknameMap = new LinkedHashMap<>();
+      nicknameMap.put(701L, "member-alice");
+
+      CommentListQueryResult out = converter.getQueryResult(rm, nicknameMap);
+
+      assertThat(out.activeComments()).isEqualTo(79L);
+      assertThat(out.totalPages()).isEqualTo(4);
+      assertThat(out.currentPage()).isEqualTo(1);
+      assertThat(out.nextPage()).isEqualTo(2);
+      assertThat(out.size()).isEqualTo(10);
+
+      assertThat(out.comments()).hasSize(2);
+      assertThat(out.comments().get(0).commentId()).isEqualTo(1L);
+      assertThat(out.comments().get(0).commentType()).isEqualTo(CommentType.GUEST);
+      assertThat(out.comments().get(0).nickname()).isEqualTo("guest-alice"); // GUEST → 원본 유지
+
+      assertThat(out.comments().get(1).commentId()).isEqualTo(2L);
+      assertThat(out.comments().get(1).commentType()).isEqualTo(CommentType.MEMBER);
+      assertThat(out.comments().get(1).nickname()).isEqualTo("member-alice"); // MEMBER → map 적용
+    }
+
+    @Test
+    @DisplayName("nicknameMap에 없는 MEMBER writerId → null 반환(현재 구현)")
+    void missingMemberNicknameBecomesNull() {
+      var rows = List.of(rmSummary(3L, 0L, CommentType.MEMBER, null, 999L, "m-unknown"));
+      var rm = readModel(rows);
+
+      CommentListQueryResult out = converter.getQueryResult(rm, Map.of());
+      assertThat(out.comments()).hasSize(1);
+      assertThat(out.comments().get(0).nickname()).isNull();
+    }
+
+    @Test
+    @DisplayName("입력 순서 보존 및 공통 메타데이터 보존")
+    void preserveOrderAndMeta() {
+      var rows =
+          List.of(
+              rmSummary(10L, 0L, CommentType.GUEST, "g1", null, "x"),
+              rmSummary(11L, 0L, CommentType.GUEST, "g2", null, "y"));
+      var rm = readModel(rows);
+
+      CommentListQueryResult out = converter.getQueryResult(rm, Map.of());
+      assertThat(out.comments())
+          .extracting(CommentListQueryResult.CommentSummary::commentId)
+          .containsExactly(10L, 11L);
+      assertThat(out.activeComments()).isEqualTo(79L);
+      assertThat(out.size()).isEqualTo(10);
+    }
+  }
+}

--- a/src/test/java/com/simpleboard/board/board/domain/comment/repository/CommentCommandRepositoryTest.java
+++ b/src/test/java/com/simpleboard/board/board/domain/comment/repository/CommentCommandRepositoryTest.java
@@ -12,12 +12,17 @@ import com.simpleboard.board.board.domain.comment.vo.CommentType;
 import com.simpleboard.board.board.domain.common.vo.Visitor;
 import com.simpleboard.board.board.domain.common.vo.VisitorType;
 import com.simpleboard.board.board.infrastructure.jpa.converter.CommentConverter;
+import com.simpleboard.board.board.infrastructure.jpa.entity.CommentEntity;
 import com.simpleboard.board.board.infrastructure.jpa.repository.CommentCommandRepositoryImpl;
+import com.simpleboard.board.board.infrastructure.jpa.repository.CommentEntityRepository;
 import com.simpleboard.board.testconfig.JpaAuditTestConfig;
-import java.util.Optional;
+import java.util.*;
+import java.util.concurrent.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -33,7 +38,9 @@ import org.springframework.test.context.ActiveProfiles;
 @Import({CommentCommandRepositoryImpl.class, CommentConverter.class, JpaAuditTestConfig.class})
 class CommentCommandRepositoryTest {
 
+  private static final Logger log = LoggerFactory.getLogger(CommentCommandRepositoryTest.class);
   @Autowired CommentCommandRepository repository;
+  @Autowired CommentEntityRepository entityRepository;
 
   @Nested
   @DisplayName("save")
@@ -131,6 +138,113 @@ class CommentCommandRepositoryTest {
     }
   }
 
+  @Nested
+  @DisplayName("Insert Concurrency")
+  class ConcurrencyTest {
+
+    private final int THREADS = 10;
+
+    @Test
+    @DisplayName("sibling_seq 동시성 테스트 - Root Comment")
+    void insert_parent_comment_at_once() throws InterruptedException {
+
+      ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+      CyclicBarrier startLine = new CyclicBarrier(THREADS);
+      CountDownLatch done = new CountDownLatch(THREADS);
+
+      List<Future<Long>> futures = new ArrayList<>(THREADS);
+
+      for (int i = 0; i < THREADS; i++) {
+        futures.add(
+            pool.submit(
+                () -> {
+                  try {
+                    startLine.await(100, TimeUnit.MILLISECONDS);
+                  } catch (Exception ignored) {
+                    log.debug("setting error");
+                  }
+                  try {
+                    Comment comment = Comment.write(guestParams());
+                    return repository.save(comment).getId();
+                  } catch (Exception e) {
+                    e.printStackTrace();
+                    throw e;
+                  } finally {
+                    done.countDown();
+                  }
+                }));
+      }
+
+      done.await(1, TimeUnit.SECONDS);
+      pool.shutdown();
+
+      assertThat(futures.stream().filter(f -> !f.isDone()).count()).isEqualTo(0);
+
+      Set<Integer> set = new HashSet<>();
+      entityRepository.findAll().stream()
+          .forEach(
+              c -> {
+                assertThat(set.contains(c.getSiblingSeq())).isFalse();
+                set.add(c.getSiblingSeq());
+              });
+      assertThat(set.size()).isEqualTo(THREADS);
+    }
+
+    @Test
+    @DisplayName("sibling_seq 동시성 테스트 - Child Comment")
+    void insert_child_comment_at_once() throws InterruptedException {
+
+      ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+      CyclicBarrier startLine = new CyclicBarrier(THREADS);
+      CountDownLatch done = new CountDownLatch(THREADS);
+
+      List<Future<Long>> futures = new ArrayList<>(THREADS);
+
+      Comment parent = Comment.write(guestParams());
+      Comment saved = repository.save(parent);
+      Long parentId = saved.getId();
+
+      for (int i = 0; i < THREADS; i++) {
+        futures.add(
+            pool.submit(
+                () -> {
+                  try {
+                    startLine.await(100, TimeUnit.MILLISECONDS);
+                  } catch (Exception ignored) {
+                    log.debug("setting error");
+                  }
+                  try {
+                    Comment comment = Comment.write(guestParams(parentId));
+                    return repository.save(comment).getId();
+                  } catch (Exception e) {
+                    e.printStackTrace();
+                    throw e;
+                  } finally {
+                    done.countDown();
+                  }
+                }));
+      }
+
+      done.await(1, TimeUnit.SECONDS);
+      pool.shutdown();
+
+      Set<Integer> set = new HashSet<>();
+      List<CommentEntity> all = entityRepository.findAll();
+
+      assertThat(futures.stream().filter(f -> !f.isDone()).count()).isEqualTo(0);
+
+      all.stream()
+          .filter(c -> c.getParentId().equals(parentId))
+          .forEach(
+              c -> {
+                assertThat(set.contains(c.getSiblingSeq())).isFalse();
+                set.add(c.getSiblingSeq());
+              });
+
+      assertThat(set.size()).isEqualTo(THREADS);
+    }
+  }
+
   private CommentCreateParams guestParams() {
     return CommentCreateParams.builder()
         .postId(100L)
@@ -138,6 +252,17 @@ class CommentCommandRepositoryTest {
         .content("hello-guest")
         .commentType(CommentType.GUEST)
         .nickname("게스트닉")
+        .password("pass-1234")
+        .build();
+  }
+
+  private CommentCreateParams guestParams(Long parentId) {
+    return CommentCreateParams.builder()
+        .postId(100L)
+        .parentCommentId(parentId)
+        .content("hello-guest-child")
+        .commentType(CommentType.GUEST)
+        .nickname("child")
         .password("pass-1234")
         .build();
   }

--- a/src/test/java/com/simpleboard/board/board/infrastructure/jpa/converter/CommentConverterUnitTest.java
+++ b/src/test/java/com/simpleboard/board/board/infrastructure/jpa/converter/CommentConverterUnitTest.java
@@ -87,7 +87,7 @@ class CommentConverterUnitTest {
     assertThat(entity).isInstanceOf(MemberCommentEntity.class);
     MemberCommentEntity me = (MemberCommentEntity) entity;
     assertThat(me.getId()).isEqualTo(202L);
-    assertThat(me.getParentId()).isNull();
+    assertThat(me.getParentId()).isEqualTo(0);
     assertThat(me.getPostId()).isEqualTo(33L);
     assertThat(me.getContent()).isEqualTo("member content");
     assertThat(me.getCommentState()).isEqualTo(CommentState.ACTIVATE);

--- a/src/test/java/com/simpleboard/board/board/infrastructure/mybatis/converter/CommentQueryConverterTest.java
+++ b/src/test/java/com/simpleboard/board/board/infrastructure/mybatis/converter/CommentQueryConverterTest.java
@@ -1,0 +1,156 @@
+package com.simpleboard.board.board.infrastructure.mybatis.converter;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.simpleboard.board.board.application.query.CommentListReadModel;
+import com.simpleboard.board.board.domain.comment.vo.CommentState;
+import com.simpleboard.board.board.domain.comment.vo.CommentType;
+import com.simpleboard.board.board.infrastructure.mybatis.mapper.CommentListCondition;
+import com.simpleboard.board.board.infrastructure.mybatis.mapper.CommentSummaryData;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class CommentQueryConverterTest {
+
+  CommentQueryConverter converter = new CommentQueryConverter();
+
+  private CommentSummaryData row(
+      long id, long parentId, String type, String state, String content) {
+    return CommentSummaryData.builder()
+        .commentId(id)
+        .parentId(parentId)
+        .commentType(type) // "GUEST_COMMENT" / "MEMBER_COMMENT"
+        .commentState(state) // "ACTIVATE" 등
+        .content(content)
+        .nickname("alice")
+        .writerId(701L)
+        .createdAt(LocalDateTime.parse("2025-02-01T10:00:00"))
+        .updatedAt(LocalDateTime.parse("2025-02-01T10:00:00"))
+        .siblingSeq(1)
+        .depth(0)
+        .build();
+  }
+
+  @Nested
+  @DisplayName("toCondition()")
+  class ToCondition {
+
+    @Test
+    @DisplayName("size=0 → 기본 limit=10, page=0/음수 → offset=0")
+    void defaultLimitAndPageNormalization() {
+      var cond =
+          converter.toCondition(
+              com.simpleboard.board.board.application.query.CommentListCriteria.builder()
+                  .postId(300L)
+                  .size(0)
+                  .page(0)
+                  .build());
+
+      assertThat(cond.limit()).isEqualTo(10);
+      assertThat(cond.offset()).isEqualTo(0);
+      assertThat(cond.postId()).isEqualTo(300L);
+
+      var condNeg =
+          converter.toCondition(
+              com.simpleboard.board.board.application.query.CommentListCriteria.builder()
+                  .postId(300L)
+                  .size(0)
+                  .page(-5)
+                  .build());
+
+      assertThat(condNeg.limit()).isEqualTo(10);
+      assertThat(condNeg.offset()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("page=3, size=20 → offset=(3-1)*20")
+    void offsetCalc() {
+      var cond =
+          converter.toCondition(
+              com.simpleboard.board.board.application.query.CommentListCriteria.builder()
+                  .postId(300L)
+                  .size(20)
+                  .page(3)
+                  .build());
+
+      assertThat(cond.limit()).isEqualTo(20);
+      assertThat(cond.offset()).isEqualTo(40);
+    }
+  }
+
+  @Nested
+  @DisplayName("toReadModel()")
+  class ToReadModel {
+
+    @Test
+    @DisplayName("기본 매핑 + 페이지 산식 검증(totalPages/nextPage)")
+    void mappingAndPagination() {
+      var cond = CommentListCondition.builder().postId(300L).limit(10).offset(0).build();
+
+      List<CommentSummaryData> rows =
+          List.of(
+              row(3001L, 0L, "MEMBER_COMMENT", "ACTIVATE", "root-1"),
+              row(3002L, 0L, "GUEST_COMMENT", "ACTIVATE", "root-2"));
+
+      long active = 79L;
+      long root = 31L; // totalPages = ceil(31/10) = 4
+
+      CommentListReadModel rm = converter.toReadModel(rows, active, root, cond);
+
+      assertThat(rm.activeComments()).isEqualTo(79L);
+      assertThat(rm.totalPages()).isEqualTo(4);
+      assertThat(rm.currentPage()).isEqualTo(1);
+      assertThat(rm.nextPage()).isEqualTo(2);
+      assertThat(rm.size()).isEqualTo(10);
+      assertThat(rm.comments()).hasSize(2);
+
+      var c1 = rm.comments().get(0);
+      assertThat(c1.commentId()).isEqualTo(3001L);
+      assertThat(c1.commentType()).isEqualTo(CommentType.MEMBER);
+      assertThat(c1.commentState()).isEqualTo(CommentState.valueOf("ACTIVATE"));
+      assertThat(c1.content()).isEqualTo("root-1");
+
+      var c2 = rm.comments().get(1);
+      assertThat(c2.commentType()).isEqualTo(CommentType.GUEST);
+    }
+
+    @Test
+    @DisplayName("마지막 페이지에서 nextPage는 totalPages 초과 금지")
+    void lastPageNextClamped() {
+      var cond =
+          CommentListCondition.builder().postId(300L).limit(10).offset(30).build(); // 4페이지(1-based)
+      long root = 31L; // totalPages=4
+
+      CommentListReadModel rm = converter.toReadModel(List.of(), 79L, root, cond);
+      assertThat(rm.currentPage()).isEqualTo(4);
+      assertThat(rm.totalPages()).isEqualTo(4);
+      assertThat(rm.nextPage()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("rows=empty & rootComments=0인 경우(현 구현): totalPages=0, nextPage=0")
+    void zeroRootCommentsEdgeCase() {
+      var cond = CommentListCondition.builder().postId(300L).limit(10).offset(0).build();
+      CommentListReadModel rm = converter.toReadModel(List.of(), 0L, 0L, cond);
+
+      // 현재 구현 로직의 결과를 '그대로' 검증
+      assertThat(rm.totalPages()).isEqualTo(0);
+      assertThat(rm.currentPage()).isEqualTo(1);
+      assertThat(rm.nextPage()).isEqualTo(0);
+      assertThat(rm.comments()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("잘못된 commentType 문자열 → Enum 변환 실패(예외)")
+    void invalidEnumFails() {
+      var bad = row(1L, 0L, "UNKNOWN_KIND", "ACTIVATE", "x");
+      var cond = CommentListCondition.builder().postId(300L).limit(10).offset(0).build();
+
+      assertThatThrownBy(() -> converter.toReadModel(List.of(bad), 0L, 1L, cond))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+}

--- a/src/test/java/com/simpleboard/board/board/infrastructure/mybatis/repository/CommentQueryRepositoryImplTest.java
+++ b/src/test/java/com/simpleboard/board/board/infrastructure/mybatis/repository/CommentQueryRepositoryImplTest.java
@@ -1,0 +1,133 @@
+package com.simpleboard.board.board.infrastructure.mybatis.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import com.simpleboard.board.board.application.query.CommentListCriteria;
+import com.simpleboard.board.board.application.query.CommentListReadModel;
+import com.simpleboard.board.board.infrastructure.mybatis.converter.CommentQueryConverter;
+import com.simpleboard.board.board.infrastructure.mybatis.mapper.CommentListCondition;
+import com.simpleboard.board.board.infrastructure.mybatis.mapper.CommentQueryMapper;
+import com.simpleboard.board.board.infrastructure.mybatis.mapper.CommentSummaryData;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class CommentQueryRepositoryImplUnitTest {
+
+  private final CommentQueryMapper mapper = mock(CommentQueryMapper.class);
+  private final CommentQueryConverter converter = new CommentQueryConverter();
+  private final CommentQueryRepositoryImpl repository =
+      new CommentQueryRepositoryImpl(mapper, converter);
+
+  private CommentSummaryData row(
+      long id, long parentId, String type, String state, String content) {
+    return CommentSummaryData.builder()
+        .commentId(id)
+        .parentId(parentId)
+        .commentType(type)
+        .commentState(state)
+        .content(content)
+        .nickname("alice")
+        .writerId(701L)
+        .createdAt(LocalDateTime.parse("2025-02-01T10:00:00"))
+        .updatedAt(LocalDateTime.parse("2025-02-01T10:00:00"))
+        .siblingSeq(1)
+        .depth(0)
+        .build();
+  }
+
+  @Test
+  @DisplayName("page=0(첫 페이지) → Mapper에게 limit=10, offset=0 전달 + 페이지 메타 정합")
+  void firstPage_conditionAndMeta() {
+    // given
+    List<CommentSummaryData> rows =
+        List.of(
+            row(3001L, 0L, "MEMBER_COMMENT", "ACTIVATE", "root-1"),
+            row(3002L, 0L, "GUEST_COMMENT", "ACTIVATE", "root-2"));
+    when(mapper.getCommentList(any())).thenReturn(rows);
+    when(mapper.countRootComments(300L)).thenReturn(31L);
+    when(mapper.countActiveComments(300L)).thenReturn(79L);
+
+    // when
+    CommentListReadModel rm =
+        repository.getCommentList(
+            CommentListCriteria.builder().postId(300L).size(10).page(0).build());
+
+    // then: Mapper로 넘어간 Condition 검증
+    var captor = ArgumentCaptor.forClass(CommentListCondition.class);
+    verify(mapper, times(1)).getCommentList(captor.capture());
+    CommentListCondition used = captor.getValue();
+    assertThat(used.postId()).isEqualTo(300L);
+    assertThat(used.limit()).isEqualTo(10);
+    assertThat(used.offset()).isEqualTo(0);
+
+    verify(mapper).countRootComments(300L);
+    verify(mapper).countActiveComments(300L);
+    verifyNoMoreInteractions(mapper);
+
+    // then: 페이지 메타/데이터 검증
+    assertThat(rm.activeComments()).isEqualTo(79L);
+    assertThat(rm.totalPages()).isEqualTo(4);
+    assertThat(rm.currentPage()).isEqualTo(1);
+    assertThat(rm.nextPage()).isEqualTo(2);
+    assertThat(rm.comments()).hasSize(2);
+    assertThat(rm.comments())
+        .extracting(CommentListReadModel.CommentSummary::commentId)
+        .containsExactly(3001L, 3002L); // 입력 순서 보존
+  }
+
+  @Test
+  @DisplayName("마지막 페이지(page=4) → nextPage는 totalPages 초과 금지")
+  void lastPage_clampedNext() {
+    when(mapper.getCommentList(any())).thenReturn(List.of());
+    when(mapper.countRootComments(300L)).thenReturn(31L); // totalPages=4
+    when(mapper.countActiveComments(300L)).thenReturn(79L);
+
+    CommentListReadModel rm =
+        repository.getCommentList(
+            CommentListCriteria.builder().postId(300L).size(10).page(4).build());
+
+    var captor = ArgumentCaptor.forClass(CommentListCondition.class);
+    verify(mapper).getCommentList(captor.capture());
+    assertThat(captor.getValue().offset()).isEqualTo(30); // (4-1)*10
+
+    assertThat(rm.currentPage()).isEqualTo(4);
+    assertThat(rm.totalPages()).isEqualTo(4);
+    assertThat(rm.nextPage()).isEqualTo(4);
+  }
+
+  @Test
+  @DisplayName("size=0 → 기본 limit=10으로 정규화된 Condition이 Mapper에 전달")
+  void defaultLimitCondition() {
+    when(mapper.getCommentList(any())).thenReturn(List.of());
+    when(mapper.countRootComments(300L)).thenReturn(0L);
+    when(mapper.countActiveComments(300L)).thenReturn(0L);
+
+    repository.getCommentList(CommentListCriteria.builder().postId(300L).size(0).page(0).build());
+
+    var captor = ArgumentCaptor.forClass(CommentListCondition.class);
+    verify(mapper).getCommentList(captor.capture());
+    assertThat(captor.getValue().limit()).isEqualTo(10);
+    assertThat(captor.getValue().offset()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("page가 매우 커도(현재 구현) currentPage는 offset 기반으로 커질 수 있음(상위 계층에서 유효성 검증 권장)")
+  void pageOverflow_currentPageMayExceedTotal() {
+    when(mapper.getCommentList(any())).thenReturn(List.of());
+    when(mapper.countRootComments(300L)).thenReturn(10L); // totalPages=1 (limit=10)
+    when(mapper.countActiveComments(300L)).thenReturn(10L);
+
+    CommentListReadModel rm =
+        repository.getCommentList(
+            CommentListCriteria.builder().postId(300L).size(10).page(999).build());
+
+    // currentPage는 999로 계산될 수 있음(현 구현), nextPage는 totalPages로 클램프
+    assertThat(rm.currentPage()).isEqualTo(999);
+    assertThat(rm.totalPages()).isEqualTo(1);
+    assertThat(rm.nextPage()).isEqualTo(1);
+  }
+}


### PR DESCRIPTION
<!-- 제목은 `[도메인] PR 제목`으로 작성해주세요. (ex) [User] 소셜 로그인 필터 리팩토링 -->
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- 목록 조회 Application 계층 로직 개발
- 목록조회 Repository 로직 개발
- 목록조회 Presentation 계층(API) 개발

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->
Presentation - Application & Domain  계층에서는 1 based paging을 사용하고, Infra 계층에서는 0 based paging을 사용하도록 하였습니다.
이렇게 분리한 이유는 다음과 같습니다:
1. 사용자 경험(UX): 클라이언트(API 호출자) 입장에서는 1페이지부터 시작하는 것이 직관적입니다.  
2. DB 연산 효율성: SQL의 `LIMIT` / `OFFSET`은 0부터 시작하므로, Infra 계층에서는 0-based가 자연스럽습니다.  
3. Ubiquitous Language 사용: 비즈니스/사용자 맥락에서 “첫 페이지”는 직관적으로 1페이지이므로 Domain 모델도 1-based를 따릅니다.


### 📝 메모
<!-- PR 관련 전달사항이 있다면 이곳에 작성해주세요. -->
9/10에 작성된 커밋 4개(`42518b8` ~ `22e549f`)는 무시해주세요.  
수정된 테이블 구조를 가져오기 위해 포함된 커밋들이며, 추후 rebase 예정입니다.

또, Mapper의 SQL 은 별도의 PR로 올릴 예정입니다.
MyBatis 테스트때문에 PR이 너무 커지더라구요.

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
#124 
